### PR TITLE
Fix: link from 25 to 26

### DIFF
--- a/steps/25/README.md
+++ b/steps/25/README.md
@@ -137,7 +137,7 @@ As our app is now bound to a remote OData service, we do not need the `invoices.
 
 ***
 
-**Next:** [Step 26: Mock Server Configuration](../26/README.MD "We just ran our app against a real service, but for developing and testing our app we do not want to rely on the availability of the “real” service or put additional load on the system where the data service is located.")
+**Next:** [Step 26: Mock Server Configuration](../26/README.md "We just ran our app against a real service, but for developing and testing our app we do not want to rely on the availability of the “real” service or put additional load on the system where the data service is located.")
   
 **Previous:** [Step 24: Sorting and Grouping](../24/README.md "To make our list of invoices even more user-friendly, we sort it alphabetically instead of just showing the order from the data model. Additionally, we introduce groups and add the company that ships the products so that the data is easier to consume.")
 


### PR DESCRIPTION
upper case MD leads to error 404

reproduce:
- open https://sap-samples.github.io/ui5-typescript-walkthrough/step-25/README.html
- click on Next: Step 26: Mock Server Configuration
- error 404: https://sap-samples.github.io/ui5-typescript-walkthrough/step-26/README.MD