### PR TITLE
fix: Use native UrlSearchParams instead of deprecated UriParameters

### DIFF
--- a/steps/26/README.md
+++ b/steps/26/README.md
@@ -142,7 +142,6 @@ Finally, we call the `start` method on the `MockServer`. From this point, each r
 
 ```ts
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -151,12 +150,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/26/webapp/localService/mockserver.ts
+++ b/steps/26/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/27/webapp/localService/mockserver.ts
+++ b/steps/27/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/28/webapp/localService/mockserver.ts
+++ b/steps/28/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/29/webapp/localService/mockserver.ts
+++ b/steps/29/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/30/webapp/localService/mockserver.ts
+++ b/steps/30/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/31/webapp/localService/mockserver.ts
+++ b/steps/31/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/32/webapp/localService/mockserver.ts
+++ b/steps/32/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/33/webapp/localService/mockserver.ts
+++ b/steps/33/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/34/webapp/localService/mockserver.ts
+++ b/steps/34/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/35/webapp/localService/mockserver.ts
+++ b/steps/35/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/36/webapp/localService/mockserver.ts
+++ b/steps/36/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/37/webapp/localService/mockserver.ts
+++ b/steps/37/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate

--- a/steps/38/webapp/localService/mockserver.ts
+++ b/steps/38/webapp/localService/mockserver.ts
@@ -1,5 +1,4 @@
 import MockServer from "sap/ui/core/util/MockServer";
-import UriParameters from "sap/base/util/UriParameters";
 
 export default {
     init: function () {
@@ -8,12 +7,12 @@ export default {
             rootUri: sap.ui.require.toUrl("ui5/walkthrough/V2/Northwind/Northwind.svc/")
         });
 
-        const uriParameters = new UriParameters(window.location.href);
+        const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
         MockServer.config({
             autoRespond: true,
-            autoRespondAfter: parseInt(uriParameters.get("serverDelay") || "500")
+            autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });
 
         // simulate


### PR DESCRIPTION
Aligns TS tutorial with already updated JS tutorial.

Fixes https://github.com/SAP-docs/sapui5/issues/132.