### PR TITLE
chore: update to UI5 version 1.132.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.2.tgz",
       "integrity": "sha512-08K9ou5VNbheZFxM5tDWoqjA3ImC50DiuuJ2tj1yEPRfkp8lLLg6XAaJ4On+a0yAXor/8ay5gHnAIshRM44Kpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
         "typical": "^7.1.1"
@@ -27,17 +28,18 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.0.tgz",
-      "integrity": "sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.1.tgz",
+      "integrity": "sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -51,6 +53,7 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
       "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -61,9 +64,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
+      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -103,14 +106,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.8.tgz",
-      "integrity": "sha512-ef383X5++iZHWAXX0SXQR6ZyQhw/0KtTkrTz61WXRhFM6dhpHulO/RJz79L8S6ugZHJkOOkUrUdxgdF2YiPFnA==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.8",
-        "@babel/types": "^7.26.8",
+        "@babel/parser": "^7.26.3",
+        "@babel/types": "^7.26.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -124,6 +127,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
       "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -170,6 +174,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
       "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
@@ -226,6 +231,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
       "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -239,6 +245,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
       "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -252,6 +259,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
       "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9",
@@ -269,6 +277,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
       "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -309,6 +318,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
       "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
@@ -326,6 +336,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
       "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -339,6 +350,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
       "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -348,6 +360,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -357,6 +370,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
       "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -391,13 +405,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
-      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.8"
+        "@babel/types": "^7.26.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -540,6 +554,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
       "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -555,6 +570,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
       "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1353,10 +1369,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.9.tgz",
-      "integrity": "sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.3.tgz",
+      "integrity": "sha512-6+5hpdr6mETwSKjmJUdYw0EIkATiQhnELWlE3kJFBwSg/BGIVwVaVbX+gOXBCdc7Ln1RXZxyWGecIXhUfnl7oA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1542,6 +1559,7 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz",
       "integrity": "sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-validator-option": "^7.25.9",
@@ -1585,17 +1603,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.8.tgz",
-      "integrity": "sha512-nic9tRkjYH0oB2dzr/JoGIm+4Q6SuYeLEiIiZDwBscRMYFJ+tMAz98fuel9ZnbXViA2I0HVSSRRK8DW5fjXStA==",
+      "version": "7.26.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.8",
-        "@babel/parser": "^7.26.8",
-        "@babel/template": "^7.26.8",
-        "@babel/types": "^7.26.8",
+        "@babel/generator": "^7.26.3",
+        "@babel/parser": "^7.26.3",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1604,9 +1622,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
-      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1621,13 +1639,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
       "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1640,11 +1660,25 @@
         "node": ">=12"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1659,6 +1693,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1668,6 +1703,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1677,7 +1713,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -1687,24 +1723,26 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jsdoc/salty": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
-      "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.9.tgz",
+      "integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -1717,6 +1755,7 @@
       "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
       "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "vary": "^1.1.2"
       },
@@ -1729,6 +1768,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1742,6 +1782,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -1751,6 +1792,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -1760,11 +1802,11 @@
       }
     },
     "node_modules/@npmcli/agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
-      "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
+      "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -1773,18 +1815,15 @@
         "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/agent/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -1794,7 +1833,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -1804,13 +1843,13 @@
       }
     },
     "node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -1818,23 +1857,23 @@
       }
     },
     "node_modules/@npmcli/config": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-8.3.4.tgz",
-      "integrity": "sha512-01rtHedemDNhUXdicU7s+QYz/3JyV5Naj84cvdXGH4mgCdL+agmSYaLF4LUG4vMCLzhBO8YtS0gPpH1FGvbgAw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-9.0.0.tgz",
+      "integrity": "sha512-P5Vi16Y+c8E0prGIzX112ug7XxqfaPFUVW/oXAV+2VsxplKZEnJozqZ0xnK8V8w/SEsBf+TXhUihrEIAU4CA5Q==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/map-workspaces": "^3.0.2",
-        "@npmcli/package-json": "^5.1.1",
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/package-json": "^6.0.1",
         "ci-info": "^4.0.0",
-        "ini": "^4.1.2",
-        "nopt": "^7.2.1",
-        "proc-log": "^4.2.0",
+        "ini": "^5.0.0",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5",
         "walk-up-path": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/config/node_modules/semver": {
@@ -1842,7 +1881,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1851,16 +1890,16 @@
       }
     },
     "node_modules/@npmcli/fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
-      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+      "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
@@ -1868,7 +1907,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1877,24 +1916,24 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.8.tgz",
-      "integrity": "sha512-liASfw5cqhjNW9UFd+ruwwdEf/lbOAQjLL2XY2dFW/bkJheXDYZgOyul/4gVvEV4BWkTXjYGmDqMw9uegdbJNQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.1.tgz",
+      "integrity": "sha512-BBWMMxeQzalmKadyimwb2/VVQyJB01PH0HhVSNLHNBDZN/M/h/02P6f8fxedIiFhpMj11SO9Ep5tKTBE7zL2nw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^7.0.0",
-        "ini": "^4.1.3",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "ini": "^5.0.0",
         "lru-cache": "^10.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^4.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "proc-log": "^5.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
-        "which": "^4.0.0"
+        "which": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/git/node_modules/isexe": {
@@ -1902,7 +1941,7 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
@@ -1912,7 +1951,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1921,11 +1960,11 @@
       }
     },
     "node_modules/@npmcli/git/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -1933,79 +1972,79 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/installed-package-contents": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-2.1.0.tgz",
-      "integrity": "sha512-c8UuGLeZpm69BryRykLuKRyKFZYJsZSCT4aVY5ds4omyZqJ172ApzgfKJ5eV/r3HgLdUYgFVe54KSFVjKoe27w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-3.0.0.tgz",
+      "integrity": "sha512-fkxoPuFGvxyrH+OQzyTkX2LUEamrF4jZSmxjAtPPHHGO0dqsQ8tTKjnIS8SAnPHdk2I03BDtSMR5K/4loKg79Q==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "npm-bundled": "^3.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
+        "npm-bundled": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
       },
       "bin": {
         "installed-package-contents": "bin/index.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/map-workspaces": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-3.0.6.tgz",
-      "integrity": "sha512-tkYs0OYnzQm6iIRdfy+LcLBjcKuQCeE5YLb8KnrIlutJfheNaPvPpgoFEyEFgbjzl5PLZ3IA/BWAwRU0eHuQDA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-4.0.2.tgz",
+      "integrity": "sha512-mnuMuibEbkaBTYj9HQ3dMe6L0ylYW+s/gfz7tBDMFY/la0w9Kf44P9aLn4/+/t3aTR3YUHKoT6XQL9rlicIe3Q==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/name-from-folder": "^2.0.0",
+        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
         "glob": "^10.2.2",
-        "minimatch": "^9.0.0",
-        "read-package-json-fast": "^3.0.0"
+        "minimatch": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/name-from-folder": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-2.0.0.tgz",
-      "integrity": "sha512-pwK+BfEBZJbKdNYpHHRTNBwBoqrN/iIMO0AiGvYsp3Hoaq0WbgGSWQR6SCldZovoDpY3yje5lkFUe6gsDgJ2vg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-3.0.0.tgz",
+      "integrity": "sha512-61cDL8LUc9y80fXn+lir+iVt8IS0xHqEKwPu/5jCjxQTVoSCmkXvw4vbMrzAMtmghz3/AkiBjhHkDKUH+kf7kA==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/node-gyp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-3.0.0.tgz",
-      "integrity": "sha512-gp8pRXC2oOxu0DUE1/M3bYtb1b3/DbJ5aM113+XJBgfXdussRAsX0YOrOhdd8WvnAR6auDBvJomGAkLKA5ydxA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-4.0.0.tgz",
+      "integrity": "sha512-+t5DZ6mO/QFh78PByMq1fGSAub/agLJZDRfJRMeOSNCt8s9YVlTjmGpIPwPhvXTGUIJk+WszlT0rQa1W33yzNA==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.2.0.tgz",
-      "integrity": "sha512-qe/kiqqkW0AGtvBjL8TJKZk/eBBSpnJkUWvHdQ9jM2lKHXRYYJuyNpJPlJw3c8QjC2ow6NZYiLExhUaeJelbxQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.1.0.tgz",
+      "integrity": "sha512-t6G+6ZInT4X+tqj2i+wlLIeCKnKOTuz9/VFYDtj+TGTur5q7sp/OYrQA19LdBbWfXDOi0Y4jtedV6xtB8zQ9ug==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.0",
+        "@npmcli/git": "^6.0.0",
         "glob": "^10.2.2",
-        "hosted-git-info": "^7.0.0",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^6.0.0",
-        "proc-log": "^4.0.0",
+        "hosted-git-info": "^8.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "normalize-package-data": "^7.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/package-json/node_modules/semver": {
@@ -2013,7 +2052,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2022,16 +2061,16 @@
       }
     },
     "node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
-      "integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-8.0.2.tgz",
+      "integrity": "sha512-/bNJhjc+o6qL+Dwz/bqfTQClkEO5nTQ1ZEcdCkAQjhkZMHIh22LPG7fNh1enJP1NKWDqYiiABnjFCY7E0zHYtQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "which": "^4.0.0"
+        "which": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
@@ -2039,17 +2078,17 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@npmcli/promise-spawn/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -2057,35 +2096,35 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/redact": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-2.0.1.tgz",
-      "integrity": "sha512-YgsR5jCQZhVmTJvjduTOIHph0L73pK8xwMVaDY0PatySqVM9AZj93jpoXYSJqfHFxFkN9dmqTw6OiqExsS3LPw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-3.0.0.tgz",
+      "integrity": "sha512-/1uFzjVcfzqrgCeGW7+SZ4hv0qLWmKXVzFahZGJ6QuJBj6Myt9s17+JL86i76NV9YSnJRcGXJYQbAU0rn1YTCQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-8.1.0.tgz",
-      "integrity": "sha512-y7efHHwghQfk28G2z3tlZ67pLG0XdfYbcVG26r7YIXALRsrVQcTq4/tdenSmdOrEsNahIYA/eh8aEVROWGFUDg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-9.0.2.tgz",
+      "integrity": "sha512-cJXiUlycdizQwvqE1iaAb4VRUM3RX09/8q46zjvy+ct9GhfZRWd7jXYVc1tn/CfRlGPVkX/u4sstRlepsm7hfw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "node-gyp": "^10.0.0",
-        "proc-log": "^4.0.0",
-        "which": "^4.0.0"
+        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "node-gyp": "^11.0.0",
+        "proc-log": "^5.0.0",
+        "which": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/run-script/node_modules/isexe": {
@@ -2093,17 +2132,17 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@npmcli/run-script/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -2111,7 +2150,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2119,32 +2158,33 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@sigstore/bundle": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
-      "integrity": "sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-3.0.0.tgz",
+      "integrity": "sha512-XDUYX56iMPAn/cdgh/DTJxz5RWmqKV4pwvUAEKEWJl+HzKdCd/24wUa9JYNMlDSCb7SUHAdtksxYX779Nne/Zg==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.3.2"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@sigstore/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-JzBqdVIyqm2FRQCulY6nbQzMpJJpSiJ8XXWMhtOX9eKgaXXpfNOF53lzQEjIydlStnd/eFtuC1dW4VYdD93oRg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-nYxaSb/MtlSI+JWcwTHQxyNmWeWrUXJJ/G4liLrGG7+tS4vAz6LF3xRXqLH6wPIVUoZQel2Fs4ddLx4NCpiIYg==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@sigstore/protobuf-specs": {
@@ -2152,56 +2192,69 @@
       "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.2.tgz",
       "integrity": "sha512-c6B0ehIWxMI8wiS/bj6rHMPqeFvngFV7cDU/MY+B16P9Z3Mp9k8L93eYZ7BYzSickzuqAQqAq0V956b3Ju6mLw==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.2.tgz",
-      "integrity": "sha512-5Vz5dPVuunIIvC5vBb0APwo7qKA4G9yM48kPWJT+OEERs40md5GoUR1yedwpekWZ4m0Hhw44m6zU+ObsON+iDA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-3.0.0.tgz",
+      "integrity": "sha512-UjhDMQOkyDoktpXoc5YPJpJK6IooF2gayAr5LvXI4EL7O0vd58okgfRcxuaH+YTdhvb5aa1Q9f+WJ0c2sVuYIw==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.3.2",
-        "@sigstore/core": "^1.0.0",
+        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/core": "^2.0.0",
         "@sigstore/protobuf-specs": "^0.3.2",
-        "make-fetch-happen": "^13.0.1",
-        "proc-log": "^4.2.0",
+        "make-fetch-happen": "^14.0.1",
+        "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@sigstore/tuf": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.3.4.tgz",
-      "integrity": "sha512-44vtsveTPUpqhm9NCrbU8CWLe3Vck2HO1PNLw7RIajbB7xhtn5RBPm1VNSCMwqGYHhDsBJG8gDF0q4lgydsJvw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-3.0.0.tgz",
+      "integrity": "sha512-9Xxy/8U5OFJu7s+OsHzI96IX/OzjF/zj0BSSaWhgJgTqtlBhQIV2xdrQI5qxLD7+CWWDepadnXAxzaZ3u9cvRw==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.3.2",
-        "tuf-js": "^2.2.1"
+        "tuf-js": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@sigstore/verify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-1.2.1.tgz",
-      "integrity": "sha512-8iKx79/F73DKbGfRf7+t4dqrc0bRr0thdPrxAtCKWRm/F0tG71i6O1rvlnScncJLLBZHn3h8M3c1BSUAb9yu8g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-2.0.0.tgz",
+      "integrity": "sha512-Ggtq2GsJuxFNUvQzLoXqRwS4ceRfLAJnrIHUDrzAD0GgnOhwujJkKkxM/s5Bako07c3WtAs/sZo5PJq7VHjeDg==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.3.2",
-        "@sigstore/core": "^1.1.0",
+        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/core": "^2.0.0",
         "@sigstore/protobuf-specs": "^0.3.2"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -2209,6 +2262,7 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -2218,23 +2272,23 @@
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
       "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@tufjs/models": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.1.tgz",
-      "integrity": "sha512-92F7/SFyufn4DXsha9+QfKnN03JGqtMFMXgSHbZOo8JG59WkTni7UzAouNQDf7AuP9OAMxVOPQcqG3sB7w+kkg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-3.0.1.tgz",
+      "integrity": "sha512-UUYHISyhCU3ZgN8yaear3cGATHb3SMuKHsQ/nVbHXcmnBf+LzQ/cQfhNG+rfaSHgqGKNEm2cOCLVLELStUQ1JA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.4"
+        "minimatch": "^9.0.5"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@types/gensync": {
@@ -2249,15 +2303,17 @@
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
       "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.30.tgz",
-      "integrity": "sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
+      "integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/sizzle": "*"
       }
@@ -2267,14 +2323,14 @@
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -2285,15 +2341,16 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.8.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.7.tgz",
-      "integrity": "sha512-LidcG+2UeYIWcMuMUpBKOnryBWG/rnmOHQR5apjn8myTQcx3rinFRn7DcIFhMnS0PPFSC6OafdIKEad0lj6U0Q==",
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -2301,56 +2358,58 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/openui5": {
-      "version": "1.126.0",
-      "resolved": "https://registry.npmjs.org/@types/openui5/-/openui5-1.126.0.tgz",
-      "integrity": "sha512-a8K9X6lUB/EiYzqoeGlOOXcyntqPIHTsO+di9yVQkAIXd0uoTMfHR3OTEK4tFgOejZi6VuWBYmweIy9FONA03Q==",
+      "version": "1.131.0",
+      "resolved": "https://registry.npmjs.org/@types/openui5/-/openui5-1.131.0.tgz",
+      "integrity": "sha512-xrmvbYa/AfAWlrkrchLFKa+sVFWqRzRth1aOJpjATGh8OYX+9GfLGvQz/+w65y6YUeLNKMe+jHwWvm07S6YH2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/jquery": "~3.5.13",
         "@types/qunit": "^2.5.4"
       }
     },
     "node_modules/@types/qunit": {
-      "version": "2.19.10",
-      "resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.19.10.tgz",
-      "integrity": "sha512-gVB+rxvxmbyPFWa6yjjKgcumWal3hyqoTXI0Oil161uWfo1OCzWZ/rnEumsx+6uVgrwPrCrhpQbLkzfildkSbg==",
-      "dev": true
+      "version": "2.19.12",
+      "resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.19.12.tgz",
+      "integrity": "sha512-II+C1wgzUia0g+tGAH+PBb4XiTm8/C/i6sN23r21NNskBYOYrv+qnW0tFQ/IxZzKVwrK4CTglf8YO3poJUclQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
-      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
-      "dev": true
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
+      "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ui5/builder": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-3.5.1.tgz",
-      "integrity": "sha512-RpiWIarR876+CILtbzCM0hAjMA0oYkS6N/UIocnwPIOKCfZKrDJnpBoAnzgyq/fOF+jm9XXhSnJrkXnyvPPysw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-4.0.5.tgz",
+      "integrity": "sha512-2b3UbS2rgsuRX+STJ+xSDsWU7f0bRZKlwoDvv+wYo1zDPPqgRgs5vK1MATxnMC8EsT8L5ncu/fgAb0h9uzuUnQ==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@ui5/fs": "^3.0.5",
-        "@ui5/logger": "^3.0.0",
-        "cheerio": "1.0.0-rc.12",
+        "@ui5/fs": "^4.0.1",
+        "@ui5/logger": "^4.0.1",
+        "cheerio": "1.0.0",
         "escape-unicode": "^0.2.0",
         "escope": "^4.0.0",
-        "espree": "^9.6.1",
+        "espree": "^10.3.0",
         "graceful-fs": "^4.2.11",
-        "jsdoc": "^4.0.3",
+        "jsdoc": "^4.0.4",
         "less-openui5": "^0.11.6",
         "pretty-data": "^0.40.0",
-        "rimraf": "^5.0.9",
         "semver": "^7.6.3",
-        "terser": "^5.31.3",
-        "workerpool": "^6.5.1",
+        "terser": "^5.37.0",
+        "workerpool": "^9.2.0",
         "xml2js": "^0.6.2"
       },
       "engines": {
-        "node": "^16.18.0 || >=18.12.0",
+        "node": "^20.11.0 || >=22.0.0",
         "npm": ">= 8"
       }
     },
@@ -2359,7 +2418,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8427,24 +8486,24 @@
       "dev": true
     },
     "node_modules/@ui5/fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@ui5/fs/-/fs-3.0.5.tgz",
-      "integrity": "sha512-SpDoMvOGYeBR8xOTDb1cu0uxJNsC1FxrENsZiRMd6R2PfUAiR0fiWQHn4dVBspoLx+jFemAfLfTMv1DEn0m1qQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ui5/fs/-/fs-4.0.1.tgz",
+      "integrity": "sha512-vVphxHk0yywJ0eseBNQ2rd1JdUZSUUZ0CAjZ3ghttqD8hx8elJjc7UllpOduysDcdaH3+Km2oLw9yumz14+lgg==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@ui5/logger": "^3.0.0",
+        "@ui5/logger": "^4.0.1",
         "clone": "^2.1.2",
         "escape-string-regexp": "^5.0.0",
-        "globby": "^13.2.2",
+        "globby": "^14.0.2",
         "graceful-fs": "^4.2.11",
-        "micromatch": "^4.0.5",
-        "minimatch": "^9.0.3",
+        "micromatch": "^4.0.8",
+        "minimatch": "^10.0.1",
         "pretty-hrtime": "^1.0.3",
         "random-int": "^3.0.0"
       },
       "engines": {
-        "node": "^16.18.0 || >=18.12.0",
+        "node": "^20.11.0 || >=22.0.0",
         "npm": ">= 8"
       }
     },
@@ -8453,7 +8512,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -8462,101 +8521,124 @@
       }
     },
     "node_modules/@ui5/fs/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
         "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/fs/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ui5/fs/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/fs/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ui5/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ui5/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-Np9pHhr+dnyL2gDFwIx6c6Xy0yhtpBIqUQM9An8uLX/wIcRjIjBSQ/r16o3YgS9roY59I/uj5ZEbIa1cdS3Dzg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ui5/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-M6ftnWiUXq3SVLLQ5XTBoJNdxzDvu71FoGh4iIR2kpaDCgpQ5DbHuBRhKAlrUB6EmIFzOxKepgYN95z09xbCbA==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^5.2.0",
-        "cli-progress": "^3.11.2",
-        "figures": "^5.0.0"
+        "chalk": "^5.3.0",
+        "cli-progress": "^3.12.0",
+        "figures": "^6.1.0"
       },
       "engines": {
-        "node": "^16.18.0 || >=18.12.0",
+        "node": "^20.11.0 || >=22.0.0",
         "npm": ">= 8"
       }
     },
-    "node_modules/@ui5/logger/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@ui5/project": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-3.9.2.tgz",
-      "integrity": "sha512-IkpDXWWiTE7eZibcQoWi09zbXAn+FJJN3boXNpZBVUxzqiqZRVatRLWdKD4TvyLZ7FvAikkufGkl+z/h2r20cQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ui5/project/-/project-4.0.4.tgz",
+      "integrity": "sha512-uSIypfUFtLCND2mDWP+6Btr3Gk/+zuMmG5px+WiH1BkV8NoIJcD/3XZPzj1lYnaCJxwVTLPyfzTUl5xZBL4ryg==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@npmcli/config": "^8.3.3",
-        "@ui5/builder": "^3.5.0",
-        "@ui5/fs": "^3.0.5",
-        "@ui5/logger": "^3.0.0",
+        "@npmcli/config": "^9.0.0",
+        "@ui5/fs": "^4.0.1",
+        "@ui5/logger": "^4.0.1",
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
         "chalk": "^5.3.0",
         "escape-string-regexp": "^5.0.0",
-        "globby": "^13.2.2",
+        "globby": "^14.0.2",
         "graceful-fs": "^4.2.11",
         "js-yaml": "^4.1.0",
         "lockfile": "^1.0.4",
-        "make-fetch-happen": "^13.0.1",
+        "make-fetch-happen": "^14.0.3",
         "node-stream-zip": "^1.15.0",
-        "pacote": "^18.0.6",
+        "pacote": "^19.0.1",
         "pretty-hrtime": "^1.0.3",
-        "read-pkg": "^8.1.0",
-        "read-pkg-up": "^10.1.0",
+        "read-package-up": "^11.0.0",
+        "read-pkg": "^9.0.1",
         "resolve": "^1.22.8",
-        "rimraf": "^5.0.7",
-        "semver": "^7.6.2",
+        "semver": "^7.6.3",
         "xml2js": "^0.6.2",
         "yesno": "^0.4.0"
       },
       "engines": {
-        "node": "^16.18.0 || >=18.12.0",
+        "node": "^20.11.0 || >=22.0.0",
         "npm": ">= 8"
-      }
-    },
-    "node_modules/@ui5/project/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+      "peerDependencies": {
+        "@ui5/builder": "^4.0.4"
+      },
+      "peerDependenciesMeta": {
+        "@ui5/builder": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ui5/project/node_modules/escape-string-regexp": {
@@ -8564,7 +8646,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -8573,20 +8655,34 @@
       }
     },
     "node_modules/@ui5/project/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
         "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/project/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8597,7 +8693,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8605,11 +8701,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/@ui5/project/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@ui5/ts-interface-generator": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@ui5/ts-interface-generator/-/ts-interface-generator-0.9.0.tgz",
       "integrity": "sha512-CwC2dA1e58sTcVGCcbw5jnxfvChkPe+j/TEyBt7IghFpLgLMxz7doc4gjwOMhNJf4IvD3NXY0NTSWMc1whqP6A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "hjson": "3.2.2",
         "loglevel": "1.9.1",
@@ -8627,7 +8737,7 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
       "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -8637,6 +8747,7 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -8649,6 +8760,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -8658,11 +8770,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8675,7 +8787,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -8685,6 +8797,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "4"
       },
@@ -8692,26 +8805,12 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8728,28 +8827,38 @@
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "peerDependencies": {
         "ajv": ">=5.0.0"
       }
     },
     "node_modules/ansi-escape-sequences": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-6.2.2.tgz",
-      "integrity": "sha512-mBPG9BZy4dMOJQ9BehU6ph8IKslvVppbqZ8APHnpfP+Hsx/hGow5PY46lSQL1vPPi1F5XTtO6p3GcH8O9c0cUg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-6.2.4.tgz",
+      "integrity": "sha512-2KJQAG1Nk4Iyu0dJENKXQJE9smEASrpu/E0F7LSnR72tQXngKGLqfRkHbkinjNct5vvAQY4BwQNt+4Tvg73nDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2"
       },
       "engines": {
         "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -8762,6 +8871,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -8774,6 +8884,7 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -8787,6 +8898,7 @@
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
       "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "archiver-utils": "^5.0.2",
         "async": "^3.2.4",
@@ -8805,6 +8917,7 @@
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
       "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "glob": "^10.0.0",
         "graceful-fs": "^4.2.0",
@@ -8822,13 +8935,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-back": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
       "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
@@ -8837,34 +8952,39 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
       "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-timsort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
-      "dev": true
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/b4a": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
-      "dev": true
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.12",
@@ -8912,13 +9032,15 @@
       "version": "0.8.18",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.18.tgz",
       "integrity": "sha512-WpOrF76nUHijnNn10eBGOHZmXQC8JYRME9rOLxStOga7Av2VO53ehVFvVNImMksVtQuL2/7ZNxEgxnx7oo/3Hw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-plugin-transform-modules-ui5": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-modules-ui5/-/babel-plugin-transform-modules-ui5-7.7.0.tgz",
       "integrity": "sha512-Xx6hU40NZHxjWEaFUnRO89bLKc90DoWpJceJHXJT1SujHfMZLfGNNvXtx+j6JSlVgHV7hLoeV5R9Z7AbSLgy5g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-flatten": "^3.0.0",
         "doctrine": "^3.0.0",
@@ -8936,13 +9058,15 @@
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
       "integrity": "sha512-88blrUrMX3SPiGkT1GnvVY8E/7A+k6oj3MNvUtTIxJflFzXTw1bHkuJ/y039ouhFMp2prRn5cQGzokViYi1dsg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-preset-transform-ui5": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-transform-ui5/-/babel-preset-transform-ui5-7.7.0.tgz",
       "integrity": "sha512-pwnzcRjc3w9Cy1HfDegjhh/BXZzrAaNQLp3rX6u58HUq1lnPvx+UPj5mDJMBQyOVyOcXDXWS4+5smVEM1LJk/Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-plugin-transform-modules-ui5": "^7.7.0"
       }
@@ -8951,13 +9075,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
-      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
+      "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/base64-js": {
@@ -8978,13 +9104,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.1.2"
       },
@@ -8996,19 +9124,22 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -9021,20 +9152,21 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -9044,6 +9176,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -9052,9 +9185,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
       "dev": true,
       "funding": [
         {
@@ -9103,6 +9236,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -9113,6 +9247,7 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
       "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -9122,15 +9257,24 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/byte-size": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-9.0.0.tgz",
-      "integrity": "sha512-xrJ8Hki7eQ6xew55mM6TG9zHI852OoAHcPfduWWtR6yxk2upTuIZy13VioRBDyHReHDdbeDPifUboeNkK/sXXA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-9.0.1.tgz",
+      "integrity": "sha512-YLe9x3rabBrcI0cueCdLS2l5ONUKywcRpTs02B8KP9/Cimhj7o3ZccGrPnRvcbyHMbb7W79/3MUJl7iGgTXKEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/bytes": {
@@ -9138,18 +9282,19 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/cacache": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-      "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
+      "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^3.1.0",
+        "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
         "glob": "^10.2.2",
         "lru-cache": "^10.0.1",
@@ -9157,13 +9302,13 @@
         "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
+        "p-map": "^7.0.2",
+        "ssri": "^12.0.0",
+        "tar": "^7.4.3",
+        "unique-filename": "^4.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/cache-content-type": {
@@ -9171,6 +9316,7 @@
       "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
       "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-types": "^2.1.18",
         "ylru": "^1.2.0"
@@ -9179,17 +9325,29 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9199,9 +9357,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001699",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
-      "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
+      "version": "1.0.30001689",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz",
+      "integrity": "sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==",
       "dev": true,
       "funding": [
         {
@@ -9224,7 +9382,7 @@
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
       "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15"
       },
@@ -9233,10 +9391,56 @@
       }
     },
     "node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -9248,53 +9452,27 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk-template": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
-      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk-template?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18.17"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -9305,7 +9483,7 @@
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
@@ -9323,6 +9501,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -9343,19 +9522,19 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
-      "peer": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
-      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
       "dev": true,
       "funding": [
         {
@@ -9363,19 +9542,9 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cli-progress": {
@@ -9383,7 +9552,7 @@
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
       "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "string-width": "^4.2.3"
       },
@@ -9396,7 +9565,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -9406,14 +9575,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cli-progress/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -9428,7 +9597,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9441,6 +9610,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -9455,6 +9625,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -9464,6 +9635,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -9478,13 +9650,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -9499,6 +9673,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9511,6 +9686,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9528,7 +9704,7 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -9538,6 +9714,7 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -9548,6 +9725,7 @@
       "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.2.0.tgz",
       "integrity": "sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@hapi/bourne": "^3.0.0",
         "inflation": "^2.0.0",
@@ -9564,6 +9742,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -9575,21 +9754,31 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/command-line-args": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.0.tgz",
-      "integrity": "sha512-zDdHxHzlCp/gA1gy0VtPK3YL0Aob3ijJdwZ7H3HSl55hh8EziLtRlyj/od8EGRJfX8IjussC/mQkScl2Ms5Suw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
-        "find-replace": "^5.0.1",
+        "find-replace": "^5.0.2",
         "lodash.camelcase": "^4.3.0",
-        "typical": "^7.1.1"
+        "typical": "^7.2.0"
       },
       "engines": {
         "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/command-line-usage": {
@@ -9597,6 +9786,7 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
       "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -9612,6 +9802,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
       "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -9621,6 +9812,7 @@
       "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
       "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -9637,6 +9829,7 @@
       "resolved": "https://registry.npmjs.org/common-log-format/-/common-log-format-1.0.0.tgz",
       "integrity": "sha512-fFn/WPNbsTCGTTwdCpZfVZSa5mgqMEkA0gMTRApFSlEsYN+9B2FPfiqch5FT+jsv5IV1RHV3GeZvCa7Qg+jssw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "clf": "bin/cli.js"
       },
@@ -9648,13 +9841,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compress-commons": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
       "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
         "crc32-stream": "^6.0.0",
@@ -9671,6 +9866,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
       },
@@ -9683,6 +9879,7 @@
       "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.6.1.tgz",
       "integrity": "sha512-3R0kMOdL7CjJpU66fzAkCe6HNtd3AavCS4m+uW4KtJjrdGPT0SQEZieAYd+cm+lJoBznNQ4lqipYWkhBMgk00g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -9692,6 +9889,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -9704,6 +9902,7 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9712,13 +9911,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookies": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
       "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
         "keygrip": "~1.1.0"
@@ -9731,7 +9932,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
       "integrity": "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.40.0",
@@ -9751,13 +9953,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -9770,6 +9974,7 @@
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
       "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^4.0.0"
@@ -9783,15 +9988,17 @@
       "resolved": "https://registry.npmjs.org/create-mixin/-/create-mixin-3.0.0.tgz",
       "integrity": "sha512-LkdMqnWT9LaqBN4huqpUnMz56Yr1mVSoCduAd2xXefgH/YZP2sXCMAyztXjk4q8hTF/TlcDa+zQW2aTgGdjjKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -9806,7 +10013,7 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -9823,7 +10030,7 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
       },
@@ -9832,21 +10039,23 @@
       }
     },
     "node_modules/current-module-paths": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.1.tgz",
-      "integrity": "sha512-8Ga5T8oMXBaSsHq9Gj+bddX7kHSaJKsl2vaAd3ep51eQLkr4W18eFEmEZM5bLo1zrz8tt3jE1U8QK9QGhaLR4g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.2.tgz",
+      "integrity": "sha512-H4s4arcLx/ugbu1XkkgSvcUZax0L6tXUqnppGniQb8l5VjUKGHoayXE5RiriiPhYDd+kjZnaok1Uig13PKtKYQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -9861,32 +10070,17 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -9894,6 +10088,7 @@
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -9902,13 +10097,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9918,6 +10115,7 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -9928,6 +10126,7 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -9940,6 +10139,7 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -9952,7 +10152,7 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -9973,14 +10173,14 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -9996,7 +10196,7 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
       "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -10019,22 +10219,39 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.96",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz",
-      "integrity": "sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==",
+      "version": "1.5.74",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.74.tgz",
+      "integrity": "sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw==",
       "dev": true,
       "license": "ISC"
     },
@@ -10042,19 +10259,22 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
       "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -10064,24 +10284,24 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/entities": {
@@ -10089,7 +10309,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -10102,7 +10322,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -10112,26 +10332,14 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
-      "peer": true
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -10141,6 +10349,20 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -10150,6 +10372,7 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -10158,13 +10381,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -10174,7 +10399,7 @@
       "resolved": "https://registry.npmjs.org/escape-unicode/-/escape-unicode-0.2.0.tgz",
       "integrity": "sha512-7jMQuKb8nm0h/9HYLfu4NCLFwoUsd5XO6OZ1z86PbKcMf8zDK1m7nFR0iA2CCShq4TSValaLIveE8T1UBxgALQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -10184,7 +10409,7 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-4.0.0.tgz",
       "integrity": "sha512-E36qlD/r6RJHVpPKArgMoMlNJzoRJFH8z/cAZlI9lbc45zB3+S7i9k6e/MNb+7bZQzNEa6r8WKN3BovpeIBwgA==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -10194,31 +10419,31 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -10229,6 +10454,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -10242,7 +10468,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -10255,7 +10481,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -10265,7 +10491,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -10275,6 +10501,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10284,6 +10511,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10293,6 +10521,7 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -10301,13 +10530,15 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
@@ -10317,26 +10548,28 @@
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
       "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
       "dev": true,
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -10353,42 +10586,29 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
+        "is-unicode-supported": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10399,6 +10619,7 @@
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -10408,6 +10629,7 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
       "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.1",
@@ -10425,6 +10647,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -10437,6 +10660,7 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
       "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -10450,15 +10674,21 @@
       }
     },
     "node_modules/find-replace": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.1.tgz",
-      "integrity": "sha512-o5/Y8HrCNRuFF5rdNTkX8Vhv6kTFTV0t1zIoigwlCdbkA9qaapRzxvWPND2VvlFa9LBI05Q1i8ml/saMqkOJUQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "dev": true,
-      "dependencies": {
-        "array-back": "^6.2.2"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/find-up": {
@@ -10466,12 +10696,26 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/follow-redirects": {
@@ -10485,6 +10729,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -10495,10 +10740,11 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -10515,6 +10761,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10524,6 +10771,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -10538,7 +10786,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
       "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -10552,6 +10800,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -10565,6 +10814,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10574,6 +10824,7 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -10583,21 +10834,28 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "dunder-proto": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10611,6 +10869,7 @@
       "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
       "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async": "^3.2.4",
         "commander": "^13.0.0",
@@ -10633,6 +10892,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -10653,6 +10913,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -10665,6 +10926,7 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -10674,6 +10936,7 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -10689,22 +10952,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globby/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10714,13 +10969,15 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -10730,39 +10987,17 @@
       "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
       "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -10775,6 +11010,7 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -10790,6 +11026,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -10802,27 +11039,28 @@
       "resolved": "https://registry.npmjs.org/hjson/-/hjson-3.2.2.tgz",
       "integrity": "sha512-MkUeB0cTIlppeSsndgESkfFD21T2nXPRaBStLtf3cAYA2bVEFdXlodZB0TukwZiobPD1Ksax5DK4RTZeaXCI3Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "hjson": "bin/hjson"
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.0.2.tgz",
+      "integrity": "sha512-sYKnA7eGln5ov8T8gnYlkSOxFJvywzEx9BueN6xo/GKO8PGiI6uK6xx+DIGe45T3bdVjLAQDQW1aicT8z8JwQg==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -10831,12 +11069,12 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-assert": {
@@ -10844,6 +11082,7 @@
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
       "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-equal": "~1.0.1",
         "http-errors": "~1.8.0"
@@ -10857,13 +11096,14 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true,
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
       "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -10880,6 +11120,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10889,6 +11130,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -10903,6 +11145,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -10917,6 +11160,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
       "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -10941,6 +11185,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -10950,12 +11195,13 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -10979,13 +11225,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -10994,19 +11242,20 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ignore-case/-/ignore-case-0.1.0.tgz",
       "integrity": "sha512-tQS9ucNf134w040JaMWzQ0WXfDR8Vdelk8E6ITviSzE6cOY2K12kNU04lLa8yy9WtcRrKWh3sdv0Xn8uLbMjUA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ignore-walk": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.5.tgz",
-      "integrity": "sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-7.0.0.tgz",
+      "integrity": "sha512-T4gbf83A4NH95zvhVYZc+qWocBBGlpzUXLPGurJggw/WIOwicfXJChLDP/iBZnN5WqROSu5Bm3hhle4z8a8YGQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "minimatch": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -11014,19 +11263,22 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+    "node_modules/index-to-position": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+      "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflation": {
@@ -11034,6 +11286,7 @@
       "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.1.0.tgz",
       "integrity": "sha512-t54PPJHG1Pp7VQvxyVCJ9mBbjG3Hqryges9bXoOO6GExCPa+//i/d5GSuFtpx3ALLd7lgIAur6zrIlBQyJuMlQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -11042,16 +11295,17 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ini": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/ip-address": {
@@ -11059,7 +11313,7 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -11068,18 +11322,12 @@
         "node": ">= 12"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -11088,10 +11336,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -11107,6 +11356,7 @@
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -11122,6 +11372,7 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11131,6 +11382,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -11140,6 +11392,7 @@
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -11155,6 +11408,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -11162,18 +11416,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -11183,6 +11431,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
       "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -11195,6 +11444,7 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -11203,13 +11453,13 @@
       }
     },
     "node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11220,6 +11470,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -11231,19 +11482,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -11258,13 +11512,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -11277,7 +11533,7 @@
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
       "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "xmlcreate": "^2.0.4"
       }
@@ -11287,14 +11543,14 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdoc": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
-      "integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
+      "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
@@ -11324,29 +11580,17 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/jsdoc/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -11355,13 +11599,13 @@
       }
     },
     "node_modules/json-parse-even-better-errors": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-4.0.0.tgz",
+      "integrity": "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -11369,19 +11613,21 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -11394,6 +11640,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -11408,13 +11655,15 @@
       "dev": true,
       "engines": [
         "node >= 0.2.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
+      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -11431,6 +11680,7 @@
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
       "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tsscmp": "1.0.6"
       },
@@ -11443,7 +11693,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
       "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -11453,6 +11703,7 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.3.tgz",
       "integrity": "sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
@@ -11487,6 +11738,7 @@
       "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.4.1.tgz",
       "integrity": "sha512-kBH3IYPMb+iAXnrxIhXnW+gXV8OTzCu8VPDqvcDHW9SQrbkHmqPQtiZwrltNmSq6/lpipHnT7k7PsjlVD7kK0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "co-body": "^6.0.0",
         "copy-to": "^2.0.1",
@@ -11500,13 +11752,15 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
       "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/koa-compress": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-5.1.1.tgz",
       "integrity": "sha512-UgMIN7ZoEP2DuoSQmD6CYvFSLt0NReGlc2qSY4bO4Oq0L56OiD9pDG41Kj/zFmVY/A3Wvmn4BqKcfq5H30LGIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "compressible": "^2.0.18",
@@ -11521,13 +11775,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/koa-conditional-get/-/koa-conditional-get-2.0.0.tgz",
       "integrity": "sha512-FTZYr681zfyW0bz8FDc55RJrRnicz6KPv2oA3GOf6knksJd0uJdfenKud+RtBjHzO0g1tVHNjwN6gk7OfHAtbQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/koa-convert": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
       "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "co": "^4.6.0",
         "koa-compose": "^4.1.0"
@@ -11541,6 +11797,7 @@
       "resolved": "https://registry.npmjs.org/koa-etag/-/koa-etag-4.0.0.tgz",
       "integrity": "sha512-1cSdezCkBWlyuB9l6c/IFoe1ANCDdPBxkDkRiaIup40xpUub6U/wwRXoKBZw/O5BifX9OlqAjYnDyzM6+l+TAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "etag": "^1.8.1"
       }
@@ -11549,13 +11806,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
       "integrity": "sha512-+97CtHAlWDx0ndt0J8y3P12EWLwTLMXIfMnYDev3wOTwH/RpBGMlfn4bDXlMEg1u73K6XRE9BbUp+5ZAYoRYWw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/koa-json": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/koa-json/-/koa-json-2.0.2.tgz",
       "integrity": "sha512-8+dz0T2ekDuNN1svYoKPCV2txotQ3Ufg8Fn5bft1T48MPJWiC/HKmkk+3xj9EC/iNZuFYeLRazN2h2o3RSUXuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-is-json": "1",
         "streaming-json-stringify": "3"
@@ -11566,6 +11825,7 @@
       "resolved": "https://registry.npmjs.org/koa-morgan/-/koa-morgan-1.0.1.tgz",
       "integrity": "sha512-JOUdCNlc21G50afBXfErUrr1RKymbgzlrO5KURY+wmDG1Uvd2jmxUJcHgylb/mYXy2SjiNZyYim/ptUBGsIi3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "morgan": "^1.6.1"
       }
@@ -11575,6 +11835,7 @@
       "resolved": "https://registry.npmjs.org/koa-range/-/koa-range-0.3.0.tgz",
       "integrity": "sha512-Ich3pCz6RhtbajYXRWjIl6O5wtrLs6kE3nkXc9XmaWe+MysJyZO7K4L3oce1Jpg/iMgCbj+5UCiMm/rqVtcDIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "stream-slice": "^0.1.2"
       },
@@ -11587,6 +11848,7 @@
       "resolved": "https://registry.npmjs.org/koa-route/-/koa-route-4.0.1.tgz",
       "integrity": "sha512-ytLrdDPF/qTMh20BxZCNpIUY329SoGu84xjGYeNsp/jkGT3OpZfkuK646sDScVJQ9XdsLXJVMml1dXMA5EIuxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "*",
         "methods": "~1.1.0",
@@ -11598,6 +11860,7 @@
       "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
       "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "http-errors": "^1.7.3",
@@ -11612,6 +11875,7 @@
       "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
       "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^3.1.0",
         "koa-send": "^5.0.0"
@@ -11625,6 +11889,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -11634,6 +11899,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -11646,6 +11912,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11660,13 +11927,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11676,7 +11945,7 @@
       "resolved": "https://registry.npmjs.org/less-openui5/-/less-openui5-0.11.6.tgz",
       "integrity": "sha512-sQmU+G2pJjFfzRI+XtXkk+T9G0s6UmWWUfOW0utPR46C9lfhNr4DH1lNJuImj64reXYi+vOwyNxPRkj0F3mofA==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@adobe/css-tools": "^4.0.2",
         "clone": "^2.1.2",
@@ -11687,22 +11956,12 @@
         "npm": ">= 5"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -11712,6 +11971,7 @@
       "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.9.3.tgz",
       "integrity": "sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.0",
         "livereload-js": "^3.3.1",
@@ -11729,13 +11989,15 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-3.4.1.tgz",
       "integrity": "sha512-5MP0uUeVCec89ZbNOT/i97Mc+q3SxXmiUGhRFOTmhrGPn//uWVQdCvcLJDy64MSBR5MidFdOR7B9viumoavy6g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/load-module": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/load-module/-/load-module-5.0.0.tgz",
       "integrity": "sha512-zZBnYIvAuP2TprnRisam+N/A3v+JX60pvdKoHQRKyl4xlHLQQLpp7JKNyEQ6D3Si0/QIQMgXko3PtV+cx6L7mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2"
       },
@@ -11748,6 +12010,7 @@
       "resolved": "https://registry.npmjs.org/local-web-server/-/local-web-server-5.4.0.tgz",
       "integrity": "sha512-FkQT6ZuX+8ywks3Mol5nHtuKzf+Rhtp88PPJUkcU0fP6JzNi7s9a+dWRQ8WrCxlGe3vHij85A4R1uL4wRg06WA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "current-module-paths": "^1.1.1",
         "lws": "^4.1.5",
@@ -11779,6 +12042,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -11791,7 +12055,7 @@
       "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
       "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "signal-exit": "^3.0.2"
       }
@@ -11801,19 +12065,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -11826,13 +12092,15 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loglevel": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
       "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -11845,13 +12113,15 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lws": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lws/-/lws-4.1.5.tgz",
-      "integrity": "sha512-MGRogJgMXFuurf5VOUKOoBeBYYlmxvaxNX/q5SJC/GzHxAqLxcQ4I21NrGkZVmCdSladgyEyC1tm/s0sT1OMPQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lws/-/lws-4.2.0.tgz",
+      "integrity": "sha512-J6mZB9mNauMBjIEh0wCF3U5bdhhuiamwTmDQ0nCTXWp6tvXNi/3RCgc4F1UN6rGpTaKgEfDnDQEo9ThLsc0UAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@75lb/deep-merge": "^1.1.2",
         "ansi-escape-sequences": "^6.2.2",
@@ -11880,6 +12150,7 @@
       "resolved": "https://registry.npmjs.org/lws-basic-auth/-/lws-basic-auth-2.0.0.tgz",
       "integrity": "sha512-zzyoGFLQPuKaQJvHMLmmSyfT6lIvocwcDXllTVW5brD0t0YgHYopILkzja+x+MIlJX/YhNKniaTSasujniYVjw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "basic-auth": "^2.0.1"
       },
@@ -11892,6 +12163,7 @@
       "resolved": "https://registry.npmjs.org/lws-blacklist/-/lws-blacklist-3.0.0.tgz",
       "integrity": "sha512-KNXGDBmbj+UGfWMBAefe2vrfuWpEQms/9Fd7kfMScTqAKF6nrVoEs4pkxfefArG3bX0bu7jWLyB4tJGma5WC6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^4.0.1",
         "path-to-regexp": "^6.1.0"
@@ -11905,6 +12177,7 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
       "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -11914,6 +12187,7 @@
       "resolved": "https://registry.npmjs.org/lws-body-parser/-/lws-body-parser-3.0.1.tgz",
       "integrity": "sha512-HUlTGYukWRXnmAFlpJhaJWSFsfkOP4fC9fjEiYeyI0kTy0/SaMLwcLzi5hQ/eriLZNGuF+PqnhBMtOys6nPdfw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-bodyparser": "^4.4.1"
       },
@@ -11926,6 +12200,7 @@
       "resolved": "https://registry.npmjs.org/lws-compress/-/lws-compress-3.1.0.tgz",
       "integrity": "sha512-uBlpYFNBUD3FuQjXbtwasvD90w3HH6GRivknvbibSSsDQf1MtIM8WZ5fS4795n1ozTYnQD+Ai8T+Cpy0q0xuhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-compress": "^5.0.1"
       },
@@ -11938,6 +12213,7 @@
       "resolved": "https://registry.npmjs.org/lws-conditional-get/-/lws-conditional-get-3.0.0.tgz",
       "integrity": "sha512-/O+JSIB889kIYgo8QFyJJayW3W0BMRc8zPHE6F5FBGtdqpsl+UsKZHFiSmJSTRn/1HGgnmcXQz2UpbB1PQYVSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-conditional-get": "^2.0.0",
         "koa-etag": "^4.0.0"
@@ -11951,6 +12227,7 @@
       "resolved": "https://registry.npmjs.org/lws-cors/-/lws-cors-4.2.1.tgz",
       "integrity": "sha512-KXsAn0Wn8n0riJ3SDHQzEAuzTrdeQZDJIxPHWEupsImW2hnQuBZVW5zqsmfzxD8SkCDDnQyFNuQZjSlBZmexKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@koa/cors": "^5.0.0"
       },
@@ -11963,6 +12240,7 @@
       "resolved": "https://registry.npmjs.org/lws-index/-/lws-index-3.1.1.tgz",
       "integrity": "sha512-f1rjsCkrKHVbSe03lm6xQ1GNnqzq/tL5f0ge8kXJFRorpS8Sv7WDXzUsGswmGAgxPPvDj8L7E6zwD+BCjQRU8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "serve-index-75lb": "^2.0.1"
       },
@@ -11975,6 +12253,7 @@
       "resolved": "https://registry.npmjs.org/lws-json/-/lws-json-2.0.0.tgz",
       "integrity": "sha512-vqUFrAQ5BGpkMS2Mm/ZhgvUMi6Tgia7YtESG7pKjNoiSsD+TxncG0nqp8YjUh2xrEzi/SYFc/ed+9ZOl/t0A0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-json": "^2.0.2"
       },
@@ -11987,6 +12266,7 @@
       "resolved": "https://registry.npmjs.org/lws-log/-/lws-log-3.0.0.tgz",
       "integrity": "sha512-I0P5dcZkR97GQ92lyJHQlCZ6eRDota+4OQrEoVXSJQD1Dc8CFxy0+4ELYJke6RwEWmr0BwU65C1cCcSC1w5NFA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-morgan": "^1.0.1",
         "stream-log-stats": "^3.0.2"
@@ -12000,6 +12280,7 @@
       "resolved": "https://registry.npmjs.org/lws-mime/-/lws-mime-2.0.0.tgz",
       "integrity": "sha512-mfrAgRQ5+hkQ7LJ6EAgwnUeymNeYxwLXZY3UQ6C2hSTr7BqMSzm9k5O0C8wWP2dzdhChzITYKwzWbUnAYVBwtA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -12009,6 +12290,7 @@
       "resolved": "https://registry.npmjs.org/lws-range/-/lws-range-4.0.1.tgz",
       "integrity": "sha512-rUkHpsRv5Ixr+8/E4cDCz6jUi6En6hnEaDZhPb0a1GU1vasOHhGcW0qilkgf0dtS0xDJzdKixdfcCW40ankIeQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-range": "^0.3.0"
       },
@@ -12021,6 +12303,7 @@
       "resolved": "https://registry.npmjs.org/lws-request-monitor/-/lws-request-monitor-2.0.0.tgz",
       "integrity": "sha512-ZTo0/pS42qiejcYlL+wlpurSbDSS0J7pDDohqBx7jjUQkgni2Qd8cPzn/kW8QI82gXgDmdZH+ps0vheLHlgdgg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "byte-size": "^6.2.0"
       },
@@ -12033,6 +12316,7 @@
       "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-6.2.0.tgz",
       "integrity": "sha512-6EspYUCAPMc7E2rltBgKwhG+Cmk0pDm9zDtF1Awe2dczNUL3YpZ8mTs/dueOTS1hqGWBOatqef4jYMGjln7WmA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -12042,6 +12326,7 @@
       "resolved": "https://registry.npmjs.org/lws-rewrite/-/lws-rewrite-4.0.0.tgz",
       "integrity": "sha512-I9rNDyAuy/1Wz2WMWTqjxFMlUTr8CugdHlUCjIudQkt04YnRdhP32iAoRnVnLsgP1UOiM44dxTW2EomQHHfirw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
         "http-proxy-agent": "^5.0.0",
@@ -12061,6 +12346,7 @@
       "resolved": "https://registry.npmjs.org/lws-spa/-/lws-spa-4.1.1.tgz",
       "integrity": "sha512-v032GXet8j818l6vUyAlQm1HfcxPVM+Flvxptv6EcDveUJqvfNX5j1bo9PqKB8HbyEScek5OH8guFAqrSOwBNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-send": "^5.0.1"
       },
@@ -12073,6 +12359,7 @@
       "resolved": "https://registry.npmjs.org/lws-static/-/lws-static-3.1.1.tgz",
       "integrity": "sha512-4Xb6rE4gVp2ZmuiVYwvFaSsMUbQ8CwxSxzHzfK6URFz4g3vVT8+e+ekGlItp8ePf9w7u9l96HU7+QDswsmwhCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "koa-static": "^5.0.0"
       },
@@ -12085,6 +12372,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -12096,27 +12384,36 @@
       }
     },
     "node_modules/make-fetch-happen": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
-      "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
+      "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/agent": "^2.0.0",
-        "cacache": "^18.0.0",
+        "@npmcli/agent": "^3.0.0",
+        "cacache": "^19.0.1",
         "http-cache-semantics": "^4.1.1",
-        "is-lambda": "^1.0.1",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
+        "minipass-fetch": "^4.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "proc-log": "^4.2.0",
+        "negotiator": "^1.0.0",
+        "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
-        "ssri": "^10.0.0"
+        "ssri": "^12.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/markdown-it": {
@@ -12124,7 +12421,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -12142,7 +12439,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
       "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
       "dev": true,
-      "peer": true,
+      "license": "Unlicense",
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
@@ -12153,7 +12450,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12161,18 +12458,29 @@
         "node": ">= 12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
+      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -12182,6 +12490,7 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -12191,6 +12500,7 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -12200,6 +12510,7 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -12213,7 +12524,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -12226,6 +12537,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
       "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -12235,6 +12547,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -12247,6 +12560,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -12256,6 +12570,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -12271,6 +12586,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -12280,6 +12596,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -12289,7 +12606,7 @@
       "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
       "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -12298,18 +12615,18 @@
       }
     },
     "node_modules/minipass-fetch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
-      "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.0.tgz",
+      "integrity": "sha512-2v6aXUXwLP1Epd/gc32HAMIWoczx+fZwEPRHm/VwtrJzRGwR1qGZXEYV3Zp8ZjjbwaZhMrM6uHV4KVkk+XCc2w==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
+        "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
@@ -12320,7 +12637,7 @@
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -12333,7 +12650,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -12341,12 +12658,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -12359,7 +12683,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -12367,12 +12691,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -12385,51 +12716,46 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/minipass-sized/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
+      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">= 18"
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/morgan": {
@@ -12437,6 +12763,7 @@
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
       "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
@@ -12453,6 +12780,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -12461,13 +12789,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/morgan/node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -12476,16 +12806,18 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -12495,6 +12827,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -12511,28 +12844,28 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.2.0.tgz",
-      "integrity": "sha512-sp3FonBAaFe4aYTcFdZUn2NYkbP7xroPGYvQmP4Nl5PxamznItBnNCgjrVTKrEfQynInMsJvZrdmqUnysCJ8rw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.0.0.tgz",
+      "integrity": "sha512-zQS+9MTTeCMgY0F3cWPyJyRFAkVltQ1uXm+xXu/ES6KFgC6Czo1Seb9vQW2wNxSX2OrDTiqL0ojtkFxBQ0ypIw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^13.0.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^4.1.0",
+        "make-fetch-happen": "^14.0.3",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5",
-        "tar": "^6.2.1",
-        "which": "^4.0.0"
+        "tar": "^7.4.3",
+        "which": "^5.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/node-gyp/node_modules/isexe": {
@@ -12540,7 +12873,7 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
@@ -12550,7 +12883,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12559,11 +12892,11 @@
       }
     },
     "node_modules/node-gyp/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -12571,7 +12904,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/node-releases": {
@@ -12586,7 +12919,7 @@
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
       "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       },
@@ -12596,11 +12929,11 @@
       }
     },
     "node_modules/nopt": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.0.0.tgz",
+      "integrity": "sha512-1L/fTJ4UmV/lUxT2Uf006pfZKTvAgCF+chz+0OgBHO8u2Z67pE7AaAUUj7CJy0lXqHmymUvGFt6NE9R3HER0yw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "abbrev": "^2.0.0"
       },
@@ -12608,22 +12941,22 @@
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/normalize-package-data": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.0.tgz",
+      "integrity": "sha512-k6U0gKRIuNCTkwHGZqblCfLfBRh+w1vI6tBo+IeJwq2M8FUiOqhX7GH+GArQGScA7azd1WfyRCvxoXDO3hQDIA==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
+        "hosted-git-info": "^8.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
@@ -12631,7 +12964,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12644,34 +12977,35 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/npm-bundled": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-3.0.1.tgz",
-      "integrity": "sha512-+AvaheE/ww1JEwRHOrn4WHNzOxGtVp+adrg2AeZS/7KuxGUYFuBta98wYpfHBbJp6Tg6j1NKSEVHNcfZzJHQwQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-4.0.0.tgz",
+      "integrity": "sha512-IxaQZDMsqfQ2Lz37VvyyEtKLe8FsRZuysmedy/N06TU1RyVppYKXrO4xIhR0F+7ubIBox6Q7nir6fQI3ej39iA==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^3.0.0"
+        "npm-normalize-package-bin": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm-install-checks": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
-      "integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-7.1.1.tgz",
+      "integrity": "sha512-u6DCwbow5ynAX5BdiHQ9qvexme4U3qHW3MWe5NqH+NeBm0LbiH6zvGjNNew1fY+AZZUtVHbOPF3j7mJxbUzpXg==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "semver": "^7.1.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm-install-checks/node_modules/semver": {
@@ -12679,7 +13013,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12688,29 +13022,29 @@
       }
     },
     "node_modules/npm-normalize-package-bin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
+      "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm-package-arg": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-      "integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.1.tgz",
+      "integrity": "sha512-aDxjFfPV3Liw0WOBWlyZLMBqtbgbg03rmGvHDJa2Ttv7tIz+1oB5qWec4psCDFZcZi9b5XdGkPdQiJxOPzvQRQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "proc-log": "^4.0.0",
+        "hosted-git-info": "^8.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
+        "validate-npm-package-name": "^6.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm-package-arg/node_modules/semver": {
@@ -12718,7 +13052,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12727,32 +13061,32 @@
       }
     },
     "node_modules/npm-packlist": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
-      "integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-9.0.0.tgz",
+      "integrity": "sha512-8qSayfmHJQTx3nJWYbbUmflpyarbLMBc6LCAjYsiGtXxDB68HaZpb8re6zeaLGxZzDuMdhsg70jryJe+RrItVQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "ignore-walk": "^6.0.4"
+        "ignore-walk": "^7.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm-pick-manifest": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
-      "integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-10.0.0.tgz",
+      "integrity": "sha512-r4fFa4FqYY8xaM7fHecQ9Z2nE9hgNfJR+EmoKv0+chvzWkBcORX3r0FpTByP+CbOVJDladMXnPQGVN8PBLGuTQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "npm-install-checks": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "npm-package-arg": "^11.0.0",
+        "npm-install-checks": "^7.1.0",
+        "npm-normalize-package-bin": "^4.0.0",
+        "npm-package-arg": "^12.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm-pick-manifest/node_modules/semver": {
@@ -12760,7 +13094,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12769,23 +13103,23 @@
       }
     },
     "node_modules/npm-registry-fetch": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-17.1.0.tgz",
-      "integrity": "sha512-5+bKQRH0J1xG1uZ1zMNvxW0VEyoNWgJpY9UDuluPFLKDfJ9u2JmmjmTJV1srBGQOROfdBMiVvnH2Zvpbm+xkVA==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-18.0.2.tgz",
+      "integrity": "sha512-LeVMZBBVy+oQb5R6FDV9OlJCcWDU+al10oKpe+nsvcHnG24Z3uM3SvJYKfGJlfGjVU8v9liejCrUR/M5HO5NEQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/redact": "^2.0.0",
+        "@npmcli/redact": "^3.0.0",
         "jsonparse": "^1.3.1",
-        "make-fetch-happen": "^13.0.0",
+        "make-fetch-happen": "^14.0.0",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
-        "minizlib": "^2.1.2",
-        "npm-package-arg": "^11.0.0",
-        "proc-log": "^4.0.0"
+        "minipass-fetch": "^4.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^12.0.0",
+        "proc-log": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/nth-check": {
@@ -12793,7 +13127,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -12806,15 +13140,17 @@
       "resolved": "https://registry.npmjs.org/object-assign-defined/-/object-assign-defined-1.0.2.tgz",
       "integrity": "sha512-xO24o25GXklHv9k1eQUvHpNpqhfv3sXmT4yQaLXdaig0EiK9ts7M2UECjjyIpEg8ckCiSZBec0qsAr4knbgdDA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -12827,6 +13163,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -12839,6 +13176,7 @@
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -12854,6 +13192,7 @@
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -12870,13 +13209,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
       "integrity": "sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -12892,6 +13233,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -12900,16 +13242,13 @@
       }
     },
     "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
       "dev": true,
-      "peer": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12920,102 +13259,200 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/package-json-from-dist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/pacote": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-18.0.6.tgz",
-      "integrity": "sha512-+eK3G27SMwsB8kLIuj4h1FUhHtwiEUo21Tw8wNjmvdlpOEr613edv+8FUsTj/4F/VN5ywGE19X18N7CC2EJk6A==",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-19.0.1.tgz",
+      "integrity": "sha512-zIpxWAsr/BvhrkSruspG8aqCQUUrWtpwx0GjiRZQhEM/pZXrigA32ElN3vTcCPUDOFmHr6SFxwYrvVUs5NTEUg==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.0",
-        "@npmcli/installed-package-contents": "^2.0.1",
-        "@npmcli/package-json": "^5.1.0",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^8.0.0",
-        "cacache": "^18.0.0",
+        "@npmcli/git": "^6.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/run-script": "^9.0.0",
+        "cacache": "^19.0.0",
         "fs-minipass": "^3.0.0",
         "minipass": "^7.0.2",
-        "npm-package-arg": "^11.0.0",
-        "npm-packlist": "^8.0.0",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^17.0.0",
-        "proc-log": "^4.0.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-packlist": "^9.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
-        "sigstore": "^2.2.0",
-        "ssri": "^10.0.0",
+        "sigstore": "^3.0.0",
+        "ssri": "^12.0.0",
         "tar": "^6.1.11"
       },
       "bin": {
         "pacote": "bin/index.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/pacote/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pacote/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/pacote/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pacote/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pacote/node_modules/tar/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/pacote/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pacote/node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pacote/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/parse-json": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
-      "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "error-ex": "^1.3.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "lines-and-columns": "^2.0.3",
-        "type-fest": "^3.8.0"
+        "@babel/code-frame": "^7.22.13",
+        "index-to-position": "^0.1.2",
+        "type-fest": "^4.7.1"
       },
       "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse-json/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -13027,6 +13464,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -13036,6 +13474,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -13045,6 +13484,7 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13054,6 +13494,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -13062,13 +13503,15 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -13081,16 +13524,18 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "dev": true
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -13099,13 +13544,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -13118,6 +13565,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -13130,6 +13578,7 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
       "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async": "^2.6.4",
         "debug": "^3.2.7",
@@ -13144,6 +13593,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -13153,8 +13603,22 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/portfinder/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/pretty-data": {
@@ -13162,7 +13626,7 @@
       "resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz",
       "integrity": "sha512-YFLnEdDEDnkt/GEhet5CYZHCvALw6+Elyb/tp8kQG03ZSIuzeaDWpZYndCXwgqu4NAjh1PI534dhDS1mHarRnQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -13172,19 +13636,19 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/proc-log": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
-      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/process": {
@@ -13192,6 +13656,7 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -13200,21 +13665,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "dev": true,
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -13227,14 +13693,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -13244,7 +13711,7 @@
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -13259,10 +13726,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -13291,20 +13759,22 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-tick": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/random-int": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/random-int/-/random-int-3.0.0.tgz",
       "integrity": "sha512-QvewnOwigesW2WFyTHiQzR6XUUcSQO/BqmfgRz5N5GpGrKQnTf7ebMz8UtuwaET8IfO1n0wLx8/fHsI8E0Jpow==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -13317,6 +13787,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -13332,6 +13803,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -13343,139 +13815,106 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/raw-body/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/read-package-json-fast": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
-      "integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "json-parse-even-better-errors": "^3.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
-      "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/normalize-package-data": "^2.4.1",
+        "@types/normalize-package-data": "^2.4.3",
         "normalize-package-data": "^6.0.0",
-        "parse-json": "^7.0.0",
-        "type-fest": "^4.2.0"
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/read-pkg-up": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.1.0.tgz",
-      "integrity": "sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==",
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "find-up": "^6.3.0",
-        "read-pkg": "^8.1.0",
-        "type-fest": "^4.2.0"
+        "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^6.0.0"
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/readable-stream": {
@@ -13483,6 +13922,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
       "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -13499,6 +13939,7 @@
       "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -13508,6 +13949,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -13520,6 +13962,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -13532,6 +13975,7 @@
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
       "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -13611,11 +14055,25 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -13625,6 +14083,7 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13633,25 +14092,27 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/requizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
       "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.9",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
+      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -13667,6 +14128,7 @@
       "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
       "integrity": "sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "http-errors": "~1.6.2",
         "path-is-absolute": "1.0.1"
@@ -13680,6 +14142,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -13689,6 +14152,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -13703,20 +14167,22 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/resolve-path/node_modules/setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -13726,25 +14192,23 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.9.tgz",
-      "integrity": "sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "14 >=14.20 || 16 >=16.20 || >=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -13769,6 +14233,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -13791,26 +14256,29 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true,
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -13820,6 +14288,7 @@
       "resolved": "https://registry.npmjs.org/serve-index-75lb/-/serve-index-75lb-2.0.1.tgz",
       "integrity": "sha512-/d9r8bqJlFQcwy0a0nb1KnWAA+Mno+V+VaoKocdkbW5aXKRQd/+4bfnRhQRQr6uEoYwTRJ4xgztOyCJvWcpBpQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "batch": "0.6.1",
@@ -13838,6 +14307,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -13847,6 +14317,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -13856,6 +14327,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -13870,48 +14342,36 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/serve-index-75lb/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/serve-index-75lb/node_modules/setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -13924,20 +14384,79 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13951,6 +14470,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -13959,34 +14479,31 @@
       }
     },
     "node_modules/sigstore": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.3.1.tgz",
-      "integrity": "sha512-8G+/XDU8wNsJOQS5ysDVO0Etg9/2uA5gR9l4ZwijjlwxBcrU6RPfwi2+jJmbP+Ap1Hlp/nVAaEO4Fj22/SL2gQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-3.0.0.tgz",
+      "integrity": "sha512-PHMifhh3EN4loMcHCz6l3v/luzgT3za+9f8subGgeMNjbJjzH4Ij/YoX3Gvu+kaouJRIlVdTHHCREADYf+ZteA==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.3.2",
-        "@sigstore/core": "^1.0.0",
+        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/core": "^2.0.0",
         "@sigstore/protobuf-specs": "^0.3.2",
-        "@sigstore/sign": "^2.3.2",
-        "@sigstore/tuf": "^2.3.4",
-        "@sigstore/verify": "^1.2.1"
+        "@sigstore/sign": "^3.0.0",
+        "@sigstore/tuf": "^3.0.0",
+        "@sigstore/verify": "^2.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/smart-buffer": {
@@ -13994,7 +14511,7 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -14005,7 +14522,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -14016,13 +14533,13 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.1",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "socks": "^2.8.3"
       },
@@ -14031,14 +14548,11 @@
       }
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -14048,7 +14562,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14058,7 +14572,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -14069,7 +14583,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -14080,44 +14594,44 @@
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true,
-      "peer": true
+      "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
-      "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
+      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
       "dev": true,
-      "peer": true
+      "license": "CC0-1.0"
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-      "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+      "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/statuses": {
@@ -14125,6 +14639,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -14134,6 +14649,7 @@
       "resolved": "https://registry.npmjs.org/stream-log-stats/-/stream-log-stats-3.0.2.tgz",
       "integrity": "sha512-393j7aeF9iRdHvyANqEQU82UQmpw2CTxgsT83caefh+lOxavVLbVrw8Mr4zjXeZLh2+xeHZMKfVx4T0rJ/EchA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-escape-sequences": "^5.1.2",
         "byte-size": "^6.2.0",
@@ -14155,6 +14671,7 @@
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
       "integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^4.0.0"
       },
@@ -14167,6 +14684,7 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
       "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -14176,6 +14694,7 @@
       "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-6.2.0.tgz",
       "integrity": "sha512-6EspYUCAPMc7E2rltBgKwhG+Cmk0pDm9zDtF1Awe2dczNUL3YpZ8mTs/dueOTS1hqGWBOatqef4jYMGjln7WmA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -14185,6 +14704,7 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
       "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^4.0.1",
         "deep-extend": "~0.6.0",
@@ -14200,6 +14720,7 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -14209,6 +14730,7 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
       "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "reduce-flatten": "^2.0.0",
         "typical": "^5.2.0"
@@ -14221,13 +14743,15 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
       "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-via": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
       "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14237,6 +14761,7 @@
       "resolved": "https://registry.npmjs.org/streaming-json-stringify/-/streaming-json-stringify-3.1.0.tgz",
       "integrity": "sha512-axtfs3BDxAsrZ9swD163FBrXZ8dhJJp6kUI6C97TvUZG9RHKfbg9nFbXqEheFNOb3IYMEt2ag9F62sWLFUZ4ug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-stringify-safe": "5",
         "readable-stream": "2"
@@ -14247,6 +14772,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14261,22 +14787,25 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streaming-json-stringify/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/streamx": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
-      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
+      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
         "queue-tick": "^1.0.1",
@@ -14291,6 +14820,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -14300,6 +14830,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -14318,6 +14849,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -14332,6 +14864,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -14340,13 +14873,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -14359,6 +14894,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -14375,6 +14911,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -14387,6 +14924,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -14396,7 +14934,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -14409,6 +14947,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -14421,6 +14960,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -14433,6 +14973,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -14445,6 +14986,7 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -14454,21 +14996,21 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar-stream": {
@@ -14476,67 +15018,35 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tar/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/terser": {
-      "version": "5.31.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.3.tgz",
-      "integrity": "sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -14555,13 +15065,14 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/text-decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
-      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -14570,13 +15081,15 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -14589,6 +15102,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -14597,13 +15111,15 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
       },
@@ -14616,31 +15132,32 @@
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
       }
     },
     "node_modules/tuf-js": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.1.tgz",
-      "integrity": "sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-3.0.1.tgz",
+      "integrity": "sha512-+68OP1ZzSF84rTckf3FA95vJ1Zlx/uaXyiiKyPd1pA4rZNkpEvDAKmsu1xUSmbF/chCRYgZ6UZkDwC7PmzmAyA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "2.0.1",
-        "debug": "^4.3.4",
-        "make-fetch-happen": "^13.0.1"
+        "@tufjs/models": "3.0.1",
+        "debug": "^4.3.6",
+        "make-fetch-happen": "^14.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/type-fest": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.23.0.tgz",
-      "integrity": "sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==",
+      "version": "4.30.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.2.tgz",
+      "integrity": "sha512-UJShLPYi1aWqCdq9HycOL/gwsuqda1OISdBO3t8RlXQC4QvtuIz4b5FCfe2dQIWEpmlRExKmcTBfP1r9bhY7ig==",
       "dev": true,
-      "peer": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -14653,6 +15170,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -14666,6 +15184,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14675,10 +15194,11 @@
       }
     },
     "node_modules/typical": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.1.1.tgz",
-      "integrity": "sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
@@ -14688,13 +15208,14 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ui5-middleware-livereload": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ui5-middleware-livereload/-/ui5-middleware-livereload-3.1.0.tgz",
       "integrity": "sha512-wXBiA4KPhl6e4h1hVi3F7yQVH8W8heH2iUyYd+LPcJB/rnbCOdzeO2mY0mLk9Y9q1C1drvAezPhi6S5fOb56pw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "connect-livereload": "^0.6.1",
         "livereload": "^0.9.3",
@@ -14777,6 +15298,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -14804,6 +15326,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
       "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -14843,7 +15366,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ui5-utils-express/-/ui5-utils-express-1.4.0.tgz",
       "integrity": "sha512-GWoGjF3Dhbr2AL/olobzkqDa3R3Sg/M98vCIamUfdb9vtgJy88x/nOQtsOBQ94bwwSu/qJgac9NgqI3KB1pWxw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ui5.walkthrough.step01": {
       "resolved": "steps/01",
@@ -15002,13 +15526,24 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -15054,30 +15589,43 @@
         "node": ">=4"
       }
     },
-    "node_modules/unique-filename": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
+      "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "unique-slug": "^4.0.0"
+        "unique-slug": "^5.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/unique-slug": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
+      "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/universalify": {
@@ -15085,6 +15633,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -15094,6 +15643,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -15134,7 +15684,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -15143,27 +15693,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
-      "peer": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/validate-npm-package-name": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-6.0.0.tgz",
+      "integrity": "sha512-d7KLgL1LD3U3fgnvWEY1cQXoO/q6EQ1BSz48Sa149V/5zVTAbgmZIpyI8TRi6U9/JNyeYLlTKsEMPtLC27RFUg==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/vary": {
@@ -15171,15 +15722,17 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/walk-back": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
-      "integrity": "sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.1.tgz",
+      "integrity": "sha512-e/FRLDVdZQWFrAzU6Hdvpm7D7m2ina833gIKLptQykRK49mmCYHLHq7UqjPDbxbKLZkTkW1rFqbengdE3sLfdw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
@@ -15189,19 +15742,44 @@
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
       "integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==",
       "dev": true,
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -15212,6 +15790,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -15227,22 +15806,24 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
       "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.2.0.tgz",
+      "integrity": "sha512-PKZqBOCo6CYkVOwAxWxQaSF2Fvb5Iv2fCeTP7buyWI2GiynWr46NcXSgK/idoV6e60dgCBfgYc+Un3HMvmqP8w==",
       "dev": true,
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -15261,6 +15842,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -15278,6 +15860,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -15287,6 +15870,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -15301,13 +15885,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -15322,6 +15908,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -15334,6 +15921,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -15355,7 +15943,7 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
       "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -15369,7 +15957,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -15379,29 +15967,34 @@
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true,
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
-      "peer": true
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -15420,6 +16013,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -15429,6 +16023,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -15437,13 +16032,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -15458,6 +16055,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -15470,28 +16068,16 @@
       "resolved": "https://registry.npmjs.org/yesno/-/yesno-0.4.0.tgz",
       "integrity": "sha512-tdBxmHvbXPBKYIg81bMCB7bVeDmHkRzk5rVJyYYXurwKkHq/MCd8rz4HSJUP7hW0H2NlXiq8IFiWvYKEHhlotA==",
       "dev": true,
-      "peer": true
+      "license": "BSD"
     },
     "node_modules/ylru": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
       "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zip-stream": {
@@ -15499,6 +16085,7 @@
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
       "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "archiver-utils": "^5.0.0",
         "compress-commons": "^6.0.2",
@@ -15530,9 +16117,9 @@
       "name": "ui5.walkthrough.step03",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15542,9 +16129,9 @@
       "name": "ui5.walkthrough.step04",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15554,9 +16141,9 @@
       "name": "ui5.walkthrough.step05",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15566,9 +16153,9 @@
       "name": "ui5.walkthrough.step06",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15578,9 +16165,9 @@
       "name": "ui5.walkthrough.step07",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15590,9 +16177,9 @@
       "name": "ui5.walkthrough.step08",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15602,9 +16189,9 @@
       "name": "ui5.walkthrough.step09",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15614,9 +16201,9 @@
       "name": "ui5.walkthrough.step10",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15626,9 +16213,9 @@
       "name": "ui5.walkthrough.step11",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15638,9 +16225,9 @@
       "name": "ui5.walkthrough.step12",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15650,9 +16237,9 @@
       "name": "ui5.walkthrough.step13",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15662,9 +16249,9 @@
       "name": "ui5.walkthrough.step14",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15674,9 +16261,9 @@
       "name": "ui5.walkthrough.step15",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15686,9 +16273,9 @@
       "name": "ui5.walkthrough.step16",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15698,9 +16285,9 @@
       "name": "ui5.walkthrough.step17",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15710,9 +16297,9 @@
       "name": "ui5.walkthrough.step18",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15722,9 +16309,9 @@
       "name": "ui5.walkthrough.step19",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15734,9 +16321,9 @@
       "name": "ui5.walkthrough.step20",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15746,9 +16333,9 @@
       "name": "ui5.walkthrough.step21",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15758,9 +16345,9 @@
       "name": "ui5.walkthrough.step22",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15770,9 +16357,9 @@
       "name": "ui5.walkthrough.step23",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15782,9 +16369,9 @@
       "name": "ui5.walkthrough.step24",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -15794,9 +16381,9 @@
       "name": "ui5.walkthrough.step25",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -15807,9 +16394,9 @@
       "name": "ui5.walkthrough.step26",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -15820,9 +16407,9 @@
       "name": "ui5.walkthrough.step27",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -15833,9 +16420,9 @@
       "name": "ui5.walkthrough.step28",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -15846,9 +16433,9 @@
       "name": "ui5.walkthrough.step29",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -15859,9 +16446,9 @@
       "name": "ui5.walkthrough.step30",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -15872,9 +16459,9 @@
       "name": "ui5.walkthrough.step31",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -15885,9 +16472,9 @@
       "name": "ui5.walkthrough.step32",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
-        "typescript": "^5.7.3",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
+        "typescript": "^5.7.2",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -15898,8 +16485,8 @@
       "name": "ui5.walkthrough.step33",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -15912,8 +16499,8 @@
       "name": "ui5.walkthrough.step34",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -15926,8 +16513,8 @@
       "name": "ui5.walkthrough.step35",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -15940,8 +16527,8 @@
       "name": "ui5.walkthrough.step36",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -15954,8 +16541,8 @@
       "name": "ui5.walkthrough.step37",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -15968,8 +16555,8 @@
       "name": "ui5.walkthrough.step38",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.120.0",
-        "@ui5/cli": "^4.0.13",
+        "@types/openui5": "^1.131.0",
+        "@ui5/cli": "^4.0.12",
         "@ui5/ts-interface-generator": "^0.9.0",
         "local-web-server": "^5.4.0",
         "typescript": "^5.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -106,14 +106,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.8.tgz",
+      "integrity": "sha512-ef383X5++iZHWAXX0SXQR6ZyQhw/0KtTkrTz61WXRhFM6dhpHulO/RJz79L8S6ugZHJkOOkUrUdxgdF2YiPFnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.3",
-        "@babel/types": "^7.26.3",
+        "@babel/parser": "^7.26.8",
+        "@babel/types": "^7.26.8",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -314,15 +314,15 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+      "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/traverse": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -405,13 +405,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
+      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.3"
+        "@babel/types": "^7.26.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1369,15 +1369,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.3.tgz",
-      "integrity": "sha512-6+5hpdr6mETwSKjmJUdYw0EIkATiQhnELWlE3kJFBwSg/BGIVwVaVbX+gOXBCdc7Ln1RXZxyWGecIXhUfnl7oA==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.8.tgz",
+      "integrity": "sha512-bME5J9AC8ChwA7aEPJ6zym3w7aObZULHhbNLU0bKUhKsAkylkzUdq+0kdymh9rzi8nlNFl2bmldFBCKNJBUpuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
         "@babel/plugin-syntax-typescript": "^7.25.9"
       },
@@ -1603,17 +1603,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.8.tgz",
+      "integrity": "sha512-nic9tRkjYH0oB2dzr/JoGIm+4Q6SuYeLEiIiZDwBscRMYFJ+tMAz98fuel9ZnbXViA2I0HVSSRRK8DW5fjXStA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.3",
-        "@babel/parser": "^7.26.3",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.3",
+        "@babel/generator": "^7.26.8",
+        "@babel/parser": "^7.26.8",
+        "@babel/template": "^7.26.8",
+        "@babel/types": "^7.26.8",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1622,9 +1622,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
+      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1877,9 +1877,9 @@
       }
     },
     "node_modules/@npmcli/config/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1903,9 +1903,9 @@
       }
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1947,9 +1947,9 @@
       }
     },
     "node_modules/@npmcli/git/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2029,9 +2029,9 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.1.0.tgz",
-      "integrity": "sha512-t6G+6ZInT4X+tqj2i+wlLIeCKnKOTuz9/VFYDtj+TGTur5q7sp/OYrQA19LdBbWfXDOi0Y4jtedV6xtB8zQ9ug==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.1.1.tgz",
+      "integrity": "sha512-d5qimadRAUCO4A/Txw71VM7UrRZzV+NPclxz/dc+M6B2oYwjWTjqh8HA/sGQgs9VZuJ6I/P7XIAlJvgrl27ZOw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2039,18 +2039,18 @@
         "glob": "^10.2.2",
         "hosted-git-info": "^8.0.0",
         "json-parse-even-better-errors": "^4.0.0",
-        "normalize-package-data": "^7.0.0",
         "proc-log": "^5.0.0",
-        "semver": "^7.5.3"
+        "semver": "^7.5.3",
+        "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/package-json/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2100,9 +2100,9 @@
       }
     },
     "node_modules/@npmcli/redact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-3.0.0.tgz",
-      "integrity": "sha512-/1uFzjVcfzqrgCeGW7+SZ4hv0qLWmKXVzFahZGJ6QuJBj6Myt9s17+JL86i76NV9YSnJRcGXJYQbAU0rn1YTCQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-3.1.1.tgz",
+      "integrity": "sha512-3Hc2KGIkrvJWJqTbvueXzBeZlmvoOxc2jyX00yzr3+sNFquJg0N8hH4SAPLPVrkWIRQICVpVgjrss971awXVnA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -2165,13 +2165,13 @@
       }
     },
     "node_modules/@sigstore/bundle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-3.0.0.tgz",
-      "integrity": "sha512-XDUYX56iMPAn/cdgh/DTJxz5RWmqKV4pwvUAEKEWJl+HzKdCd/24wUa9JYNMlDSCb7SUHAdtksxYX779Nne/Zg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-3.1.0.tgz",
+      "integrity": "sha512-Mm1E3/CmDDCz3nDhFKTuYdB47EdRFRQMOE/EAbiG1MJW77/w1b3P7Qx7JSrVJs8PfwOLOVcKQCHErIwCTyPbag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.2"
+        "@sigstore/protobuf-specs": "^0.4.0"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2188,26 +2188,26 @@
       }
     },
     "node_modules/@sigstore/protobuf-specs": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.2.tgz",
-      "integrity": "sha512-c6B0ehIWxMI8wiS/bj6rHMPqeFvngFV7cDU/MY+B16P9Z3Mp9k8L93eYZ7BYzSickzuqAQqAq0V956b3Ju6mLw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.4.0.tgz",
+      "integrity": "sha512-o09cLSIq9EKyRXwryWDOJagkml9XgQCoCSRjHOnHLnvsivaW7Qznzz6yjfV7PHJHhIvyp8OH7OX8w0Dc5bQK7A==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-3.0.0.tgz",
-      "integrity": "sha512-UjhDMQOkyDoktpXoc5YPJpJK6IooF2gayAr5LvXI4EL7O0vd58okgfRcxuaH+YTdhvb5aa1Q9f+WJ0c2sVuYIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-3.1.0.tgz",
+      "integrity": "sha512-knzjmaOHOov1Ur7N/z4B1oPqZ0QX5geUfhrVaqVlu+hl0EAoL4o+l0MSULINcD5GCWe3Z0+YJO8ues6vFlW0Yw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.3.2",
-        "make-fetch-happen": "^14.0.1",
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "make-fetch-happen": "^14.0.2",
         "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1"
       },
@@ -2216,13 +2216,13 @@
       }
     },
     "node_modules/@sigstore/tuf": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-3.0.0.tgz",
-      "integrity": "sha512-9Xxy/8U5OFJu7s+OsHzI96IX/OzjF/zj0BSSaWhgJgTqtlBhQIV2xdrQI5qxLD7+CWWDepadnXAxzaZ3u9cvRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-3.1.0.tgz",
+      "integrity": "sha512-suVMQEA+sKdOz5hwP9qNcEjX6B45R+hFFr4LAWzbRc5O+U2IInwvay/bpG5a4s+qR35P/JK/PiKiRGjfuLy1IA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.2",
+        "@sigstore/protobuf-specs": "^0.4.0",
         "tuf-js": "^3.0.1"
       },
       "engines": {
@@ -2230,15 +2230,15 @@
       }
     },
     "node_modules/@sigstore/verify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-2.0.0.tgz",
-      "integrity": "sha512-Ggtq2GsJuxFNUvQzLoXqRwS4ceRfLAJnrIHUDrzAD0GgnOhwujJkKkxM/s5Bako07c3WtAs/sZo5PJq7VHjeDg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-2.1.0.tgz",
+      "integrity": "sha512-kAAM06ca4CzhvjIZdONAL9+MLppW3K48wOFy1TbuaWFW/OMfl8JuTgW0Bm02JB1WJGT/ET2eqav0KTEKmxqkIA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.3.2"
+        "@sigstore/protobuf-specs": "^0.4.0"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2299,9 +2299,9 @@
       "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.15",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
-      "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2344,9 +2344,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2361,9 +2361,9 @@
       "license": "MIT"
     },
     "node_modules/@types/openui5": {
-      "version": "1.131.0",
-      "resolved": "https://registry.npmjs.org/@types/openui5/-/openui5-1.131.0.tgz",
-      "integrity": "sha512-xrmvbYa/AfAWlrkrchLFKa+sVFWqRzRth1aOJpjATGh8OYX+9GfLGvQz/+w65y6YUeLNKMe+jHwWvm07S6YH2Q==",
+      "version": "1.132.0",
+      "resolved": "https://registry.npmjs.org/@types/openui5/-/openui5-1.132.0.tgz",
+      "integrity": "sha512-Cu0MKMnzkIIJhgGTON7V074jzIMsNKq6qMbuu9w7Jl5f08NuypOEAzpZ5x2D4A5Ebpr3x0NqfO2TQaBu7QoYtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/@ui5/builder/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8521,24 +8521,34 @@
       }
     },
     "node_modules/@ui5/fs/node_modules/globby": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
-      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.2",
-        "ignore": "^5.2.4",
-        "path-type": "^5.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
         "slash": "^5.1.0",
-        "unicorn-magic": "^0.1.0"
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/fs/node_modules/ignore": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@ui5/fs/node_modules/minimatch": {
@@ -8558,13 +8568,13 @@
       }
     },
     "node_modules/@ui5/fs/node_modules/path-type": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
-      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8578,6 +8588,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/fs/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8655,18 +8678,18 @@
       }
     },
     "node_modules/@ui5/project/node_modules/globby": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
-      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.2",
-        "ignore": "^5.2.4",
-        "path-type": "^5.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
         "slash": "^5.1.0",
-        "unicorn-magic": "^0.1.0"
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
         "node": ">=18"
@@ -8675,23 +8698,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@ui5/project/node_modules/path-type": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
-      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+    "node_modules/@ui5/project/node_modules/ignore": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@ui5/project/node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ui5/project/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8709,6 +8742,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ui5/project/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8733,13 +8779,13 @@
       }
     },
     "node_modules/abbrev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.0.tgz",
+      "integrity": "sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/abort-controller": {
@@ -9079,9 +9125,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
-      "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true
@@ -9185,9 +9231,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
       "funding": [
         {
@@ -9357,9 +9403,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001689",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz",
-      "integrity": "sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==",
+      "version": "1.0.30001699",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
+      "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
       "dev": true,
       "funding": [
         {
@@ -9391,9 +9437,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9798,9 +9844,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10192,9 +10238,9 @@
       }
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10249,9 +10295,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.74",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.74.tgz",
-      "integrity": "sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw==",
+      "version": "1.5.96",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.96.tgz",
+      "integrity": "sha512-8AJUW6dh75Fm/ny8+kZKJzI1pgoE8bKLZlzDU2W1ENd+DXKJrx7I7l9hb8UWR4ojlnb5OlixMt00QWiYJoVw1w==",
       "dev": true,
       "license": "ISC"
     },
@@ -10355,9 +10401,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10544,9 +10590,9 @@
       }
     },
     "node_modules/exponential-backoff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
-      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -10589,9 +10635,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10767,9 +10813,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10840,28 +10886,42 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
-        "dunder-proto": "^1.0.0",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "math-intrinsics": "^1.0.0"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gh-pages": {
@@ -11336,9 +11396,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
-      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11388,13 +11448,16 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11437,6 +11500,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -12459,9 +12541,9 @@
       }
     },
     "node_modules/math-intrinsics": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
-      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12844,9 +12926,9 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.0.0.tgz",
-      "integrity": "sha512-zQS+9MTTeCMgY0F3cWPyJyRFAkVltQ1uXm+xXu/ES6KFgC6Czo1Seb9vQW2wNxSX2OrDTiqL0ojtkFxBQ0ypIw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.1.0.tgz",
+      "integrity": "sha512-/+7TuHKnBpnMvUQnsYEb0JOozDZqarQbfNuSGLXIjhStMT0fbw7IdSqWgopOP5xhRZE+lsbIvAHcekddruPZgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12879,9 +12961,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -12929,13 +13011,13 @@
       }
     },
     "node_modules/nopt": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.0.0.tgz",
-      "integrity": "sha512-1L/fTJ4UmV/lUxT2Uf006pfZKTvAgCF+chz+0OgBHO8u2Z67pE7AaAUUj7CJy0lXqHmymUvGFt6NE9R3HER0yw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^2.0.0"
+        "abbrev": "^3.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
@@ -12945,24 +13027,37 @@
       }
     },
     "node_modules/normalize-package-data": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.0.tgz",
-      "integrity": "sha512-k6U0gKRIuNCTkwHGZqblCfLfBRh+w1vI6tBo+IeJwq2M8FUiOqhX7GH+GArQGScA7azd1WfyRCvxoXDO3hQDIA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^8.0.0",
+        "hosted-git-info": "^7.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13009,9 +13104,9 @@
       }
     },
     "node_modules/npm-install-checks/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13032,9 +13127,9 @@
       }
     },
     "node_modules/npm-package-arg": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.1.tgz",
-      "integrity": "sha512-aDxjFfPV3Liw0WOBWlyZLMBqtbgbg03rmGvHDJa2Ttv7tIz+1oB5qWec4psCDFZcZi9b5XdGkPdQiJxOPzvQRQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-12.0.2.tgz",
+      "integrity": "sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -13048,9 +13143,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13090,9 +13185,9 @@
       }
     },
     "node_modules/npm-pick-manifest/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13146,9 +13241,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13726,13 +13821,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
-      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -13760,13 +13855,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/random-int": {
@@ -13876,51 +13964,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/read-pkg/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14106,9 +14153,9 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.9",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
-      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14118,6 +14165,9 @@
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14258,6 +14308,24 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -14479,18 +14547,18 @@
       }
     },
     "node_modules/sigstore": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-3.0.0.tgz",
-      "integrity": "sha512-PHMifhh3EN4loMcHCz6l3v/luzgT3za+9f8subGgeMNjbJjzH4Ij/YoX3Gvu+kaouJRIlVdTHHCREADYf+ZteA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-3.1.0.tgz",
+      "integrity": "sha512-ZpzWAFHIFqyFE56dXqgX/DkDRZdz+rRcjoIk/RQU4IX0wiCv1l8S7ZrXDHcCc+uaf+6o7w3h2l3g6GYG5TKN9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.3.2",
-        "@sigstore/sign": "^3.0.0",
-        "@sigstore/tuf": "^3.0.0",
-        "@sigstore/verify": "^2.0.0"
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "@sigstore/sign": "^3.1.0",
+        "@sigstore/tuf": "^3.1.0",
+        "@sigstore/verify": "^2.1.0"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -14518,9 +14586,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14608,9 +14676,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -14801,14 +14869,13 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
-      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
-        "queue-tick": "^1.0.1",
         "text-decoder": "^1.1.0"
       },
       "optionalDependencies": {
@@ -15042,9 +15109,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "version": "5.38.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.38.1.tgz",
+      "integrity": "sha512-GWANVlPM/ZfYzuPHjq0nxT+EbOEDDN3Jwhwdg1D8TU8oSkktp8w64Uq4auuGLxFSoNTRDncTq2hQHX1Ld9KHkA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -15153,9 +15220,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.30.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.2.tgz",
-      "integrity": "sha512-UJShLPYi1aWqCdq9HycOL/gwsuqda1OISdBO3t8RlXQC4QvtuIz4b5FCfe2dQIWEpmlRExKmcTBfP1r9bhY7ig==",
+      "version": "4.34.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.34.1.tgz",
+      "integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -15529,9 +15596,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
-      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16117,9 +16184,9 @@
       "name": "ui5.walkthrough.step03",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16129,9 +16196,9 @@
       "name": "ui5.walkthrough.step04",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16141,9 +16208,9 @@
       "name": "ui5.walkthrough.step05",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16153,9 +16220,9 @@
       "name": "ui5.walkthrough.step06",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16165,9 +16232,9 @@
       "name": "ui5.walkthrough.step07",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16177,9 +16244,9 @@
       "name": "ui5.walkthrough.step08",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16189,9 +16256,9 @@
       "name": "ui5.walkthrough.step09",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16201,9 +16268,9 @@
       "name": "ui5.walkthrough.step10",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16213,9 +16280,9 @@
       "name": "ui5.walkthrough.step11",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16225,9 +16292,9 @@
       "name": "ui5.walkthrough.step12",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16237,9 +16304,9 @@
       "name": "ui5.walkthrough.step13",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16249,9 +16316,9 @@
       "name": "ui5.walkthrough.step14",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16261,9 +16328,9 @@
       "name": "ui5.walkthrough.step15",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16273,9 +16340,9 @@
       "name": "ui5.walkthrough.step16",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16285,9 +16352,9 @@
       "name": "ui5.walkthrough.step17",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16297,9 +16364,9 @@
       "name": "ui5.walkthrough.step18",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16309,9 +16376,9 @@
       "name": "ui5.walkthrough.step19",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16321,9 +16388,9 @@
       "name": "ui5.walkthrough.step20",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16333,9 +16400,9 @@
       "name": "ui5.walkthrough.step21",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16345,9 +16412,9 @@
       "name": "ui5.walkthrough.step22",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16357,9 +16424,9 @@
       "name": "ui5.walkthrough.step23",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16369,9 +16436,9 @@
       "name": "ui5.walkthrough.step24",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-tooling-transpile": "^3.7.1"
@@ -16381,9 +16448,9 @@
       "name": "ui5.walkthrough.step25",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -16394,9 +16461,9 @@
       "name": "ui5.walkthrough.step26",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -16407,9 +16474,9 @@
       "name": "ui5.walkthrough.step27",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -16420,9 +16487,9 @@
       "name": "ui5.walkthrough.step28",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -16433,9 +16500,9 @@
       "name": "ui5.walkthrough.step29",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -16446,9 +16513,9 @@
       "name": "ui5.walkthrough.step30",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -16459,9 +16526,9 @@
       "name": "ui5.walkthrough.step31",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -16472,9 +16539,9 @@
       "name": "ui5.walkthrough.step32",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
-        "typescript": "^5.7.2",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
+        "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
         "ui5-middleware-serveframework": "^3.5.0",
         "ui5-middleware-simpleproxy": "^3.4.0",
@@ -16485,8 +16552,8 @@
       "name": "ui5.walkthrough.step33",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -16499,8 +16566,8 @@
       "name": "ui5.walkthrough.step34",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -16513,8 +16580,8 @@
       "name": "ui5.walkthrough.step35",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -16527,8 +16594,8 @@
       "name": "ui5.walkthrough.step36",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -16541,8 +16608,8 @@
       "name": "ui5.walkthrough.step37",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
         "@ui5/ts-interface-generator": "^0.9.0",
         "typescript": "^5.7.3",
         "ui5-middleware-livereload": "^3.1.0",
@@ -16555,8 +16622,8 @@
       "name": "ui5.walkthrough.step38",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/openui5": "^1.131.0",
-        "@ui5/cli": "^4.0.12",
+        "@types/openui5": "^1.132.0",
+        "@ui5/cli": "^4.0.13",
         "@ui5/ts-interface-generator": "^0.9.0",
         "local-web-server": "^5.4.0",
         "typescript": "^5.7.3",

--- a/steps/01/README.md
+++ b/steps/01/README.md
@@ -61,10 +61,9 @@ The manifest serves as a crucial configuration file for applications, components
 
 Let's start by creating a new file named `manifest.json` in the webapp folder and define its essential attributes:
 
--   The `_version` attribute is a mandatory field in the app descriptor that indicates the format version of the descriptor. This attribute is crucial for identifying application settings when the descriptor is read by various tools. As new features or changes are introduced in future versions of the descriptor, the version number helps ensure compatibility and proper interpretation of the descriptor's contents. Consequently, with each new version of OpenUI5 a corresponding version of the app descriptor is released. For this tutorial, we have determined that our app requires a minimum OpenUI5 version of 1.131. Therefore, we specify the descriptor format version as 1.68.0, aligning it with the appropriate OpenUI5 version.
+-   The `_version` attribute in the root is mandatory in the manifest. It indicates the format version of the manifest, which is crucial for identifying application settings whenever the file is read by various tools. As new features or changes are introduced in future versions, maintaining the correct version number ensures compatibility and precise interpretation of the manifest's contents. 
 
-    > 💡 **Tip:** <br>
-    > To find the appropriate `_version` for each OpenUI5 release, see [Descriptor for Applications, Components, and Libraries \(manifest.json\)](https://sdk.openui5.org/topic/be0cf40f61184b358b5faedaec98b2da).
+Since we want our app to support not only the latest OpenUI5 version but rather the latest long-term maintenance version, which is OpenUI5 1.120, we set the format version to `1.60.0`.
 
   > 📝  **Note:** <br>
   > The manifest version should not necessarily align directly with the OpenUI5 version being used. Instead, choose the descriptor version that matches the requirements or supports the features you intend to use in your application. 

--- a/steps/01/README.md
+++ b/steps/01/README.md
@@ -61,9 +61,10 @@ The manifest serves as a crucial configuration file for applications, components
 
 Let's start by creating a new file named `manifest.json` in the webapp folder and define its essential attributes:
 
--   The `_version` attribute in the root is mandatory in the manifest. It indicates the format version of the manifest, which is crucial for identifying application settings whenever the file is read by various tools. As new features or changes are introduced in future versions, maintaining the correct version number ensures compatibility and precise interpretation of the manifest's contents. 
+-   The `_version` attribute is a mandatory field in the app descriptor that indicates the format version of the descriptor. This attribute is crucial for identifying application settings when the descriptor is read by various tools. As new features or changes are introduced in future versions of the descriptor, the version number helps ensure compatibility and proper interpretation of the descriptor's contents. Consequently, with each new version of OpenUI5 a corresponding version of the app descriptor is released. For this tutorial, we have determined that our app requires a minimum OpenUI5 version of 1.131. Therefore, we specify the descriptor format version as 1.68.0, aligning it with the appropriate OpenUI5 version.
 
-Since we want our app to support not only the latest OpenUI5 version but rather the latest long-term maintenance version, which is OpenUI5 1.120, we set the format version to `1.60.0`.
+    > 💡 **Tip:** <br>
+    > To find the appropriate `_version` for each OpenUI5 release, see [Descriptor for Applications, Components, and Libraries \(manifest.json\)](https://sdk.openui5.org/topic/be0cf40f61184b358b5faedaec98b2da).
 
   > 📝  **Note:** <br>
   > The manifest version should not necessarily align directly with the OpenUI5 version being used. Instead, choose the descriptor version that matches the requirements or supports the features you intend to use in your application. 

--- a/steps/02/README.md
+++ b/steps/02/README.md
@@ -200,7 +200,7 @@ Next,  we have to configure the tooling extension we installed from npm to our U
 ```yaml
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.ui.core
     - name: themelib_sap_horizon

--- a/steps/02/README.md
+++ b/steps/02/README.md
@@ -200,7 +200,7 @@ Next,  we have to configure the tooling extension we installed from npm to our U
 ```yaml
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.ui.core
     - name: themelib_sap_horizon

--- a/steps/02/ui5.yaml
+++ b/steps/02/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.ui.core
     - name: themelib_sap_horizon

--- a/steps/02/ui5.yaml
+++ b/steps/02/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.ui.core
     - name: themelib_sap_horizon

--- a/steps/02/webapp/index-cdn.html
+++ b/steps/02/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/02/webapp/index-cdn.html
+++ b/steps/02/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/03/package.json
+++ b/steps/03/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/03/package.json
+++ b/steps/03/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/03/ui5.yaml
+++ b/steps/03/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/03/ui5.yaml
+++ b/steps/03/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/03/webapp/index-cdn.html
+++ b/steps/03/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/03/webapp/index-cdn.html
+++ b/steps/03/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/04/package.json
+++ b/steps/04/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/04/package.json
+++ b/steps/04/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/04/ui5.yaml
+++ b/steps/04/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/04/ui5.yaml
+++ b/steps/04/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/04/webapp/index-cdn.html
+++ b/steps/04/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/04/webapp/index-cdn.html
+++ b/steps/04/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/05/package.json
+++ b/steps/05/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/05/package.json
+++ b/steps/05/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/05/ui5.yaml
+++ b/steps/05/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/05/ui5.yaml
+++ b/steps/05/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/05/webapp/index-cdn.html
+++ b/steps/05/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/05/webapp/index-cdn.html
+++ b/steps/05/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/06/package.json
+++ b/steps/06/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/06/package.json
+++ b/steps/06/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/06/ui5.yaml
+++ b/steps/06/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/06/ui5.yaml
+++ b/steps/06/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/06/webapp/index-cdn.html
+++ b/steps/06/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/06/webapp/index-cdn.html
+++ b/steps/06/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/07/package.json
+++ b/steps/07/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/07/package.json
+++ b/steps/07/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/07/ui5.yaml
+++ b/steps/07/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/07/ui5.yaml
+++ b/steps/07/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/07/webapp/index-cdn.html
+++ b/steps/07/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/07/webapp/index-cdn.html
+++ b/steps/07/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/08/package.json
+++ b/steps/08/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/08/package.json
+++ b/steps/08/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/08/ui5.yaml
+++ b/steps/08/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/08/ui5.yaml
+++ b/steps/08/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/08/webapp/index-cdn.html
+++ b/steps/08/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/08/webapp/index-cdn.html
+++ b/steps/08/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/09/package.json
+++ b/steps/09/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/09/package.json
+++ b/steps/09/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/09/ui5.yaml
+++ b/steps/09/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/09/ui5.yaml
+++ b/steps/09/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/09/webapp/index-cdn.html
+++ b/steps/09/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/09/webapp/index-cdn.html
+++ b/steps/09/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/10/README.md
+++ b/steps/10/README.md
@@ -119,7 +119,7 @@ In our current scenario, we only have one model called `i18n`, which is a resour
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/10/README.md
+++ b/steps/10/README.md
@@ -119,7 +119,7 @@ In our current scenario, we only have one model called `i18n`, which is a resour
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/10/package.json
+++ b/steps/10/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/10/package.json
+++ b/steps/10/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/10/ui5.yaml
+++ b/steps/10/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/10/ui5.yaml
+++ b/steps/10/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/10/webapp/index-cdn.html
+++ b/steps/10/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/10/webapp/index-cdn.html
+++ b/steps/10/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/10/webapp/manifest.json
+++ b/steps/10/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/10/webapp/manifest.json
+++ b/steps/10/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/11/package.json
+++ b/steps/11/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/11/package.json
+++ b/steps/11/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/11/ui5.yaml
+++ b/steps/11/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/11/ui5.yaml
+++ b/steps/11/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/11/webapp/index-cdn.html
+++ b/steps/11/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/11/webapp/index-cdn.html
+++ b/steps/11/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/11/webapp/manifest.json
+++ b/steps/11/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/11/webapp/manifest.json
+++ b/steps/11/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/12/package.json
+++ b/steps/12/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/12/package.json
+++ b/steps/12/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/12/ui5.yaml
+++ b/steps/12/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/12/ui5.yaml
+++ b/steps/12/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/12/webapp/index-cdn.html
+++ b/steps/12/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/12/webapp/index-cdn.html
+++ b/steps/12/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/12/webapp/manifest.json
+++ b/steps/12/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/12/webapp/manifest.json
+++ b/steps/12/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/13/package.json
+++ b/steps/13/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/13/package.json
+++ b/steps/13/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/13/ui5.yaml
+++ b/steps/13/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/13/ui5.yaml
+++ b/steps/13/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/13/webapp/index-cdn.html
+++ b/steps/13/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/13/webapp/index-cdn.html
+++ b/steps/13/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/13/webapp/manifest.json
+++ b/steps/13/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/13/webapp/manifest.json
+++ b/steps/13/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/14/package.json
+++ b/steps/14/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/14/package.json
+++ b/steps/14/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/14/ui5.yaml
+++ b/steps/14/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/14/ui5.yaml
+++ b/steps/14/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/14/webapp/index-cdn.html
+++ b/steps/14/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/14/webapp/index-cdn.html
+++ b/steps/14/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/14/webapp/manifest.json
+++ b/steps/14/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/14/webapp/manifest.json
+++ b/steps/14/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -55,6 +55,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }     
+        }
     }
 }

--- a/steps/15/package.json
+++ b/steps/15/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/15/package.json
+++ b/steps/15/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/15/ui5.yaml
+++ b/steps/15/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/15/ui5.yaml
+++ b/steps/15/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/15/webapp/index-cdn.html
+++ b/steps/15/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/15/webapp/index-cdn.html
+++ b/steps/15/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/15/webapp/manifest.json
+++ b/steps/15/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/15/webapp/manifest.json
+++ b/steps/15/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -55,6 +55,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }     
+        }
     }
 }

--- a/steps/16/package.json
+++ b/steps/16/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/16/package.json
+++ b/steps/16/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/16/ui5.yaml
+++ b/steps/16/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/16/ui5.yaml
+++ b/steps/16/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/16/webapp/index-cdn.html
+++ b/steps/16/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/16/webapp/index-cdn.html
+++ b/steps/16/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/16/webapp/manifest.json
+++ b/steps/16/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/16/webapp/manifest.json
+++ b/steps/16/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -55,6 +55,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }     
+        }
     }
 }

--- a/steps/17/package.json
+++ b/steps/17/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/17/package.json
+++ b/steps/17/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/17/ui5.yaml
+++ b/steps/17/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/17/ui5.yaml
+++ b/steps/17/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/17/webapp/index-cdn.html
+++ b/steps/17/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/17/webapp/index-cdn.html
+++ b/steps/17/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/17/webapp/manifest.json
+++ b/steps/17/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/17/webapp/manifest.json
+++ b/steps/17/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -55,6 +55,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }     
+        }
     }
 }

--- a/steps/18/package.json
+++ b/steps/18/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/18/package.json
+++ b/steps/18/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/18/ui5.yaml
+++ b/steps/18/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/18/ui5.yaml
+++ b/steps/18/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/18/webapp/index-cdn.html
+++ b/steps/18/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/18/webapp/index-cdn.html
+++ b/steps/18/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/18/webapp/manifest.json
+++ b/steps/18/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/18/webapp/manifest.json
+++ b/steps/18/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -55,6 +55,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }     
+        }
     }
 }

--- a/steps/19/package.json
+++ b/steps/19/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/19/package.json
+++ b/steps/19/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/19/ui5.yaml
+++ b/steps/19/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/19/ui5.yaml
+++ b/steps/19/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/19/webapp/index-cdn.html
+++ b/steps/19/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/19/webapp/index-cdn.html
+++ b/steps/19/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/19/webapp/manifest.json
+++ b/steps/19/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -59,6 +59,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/19/webapp/manifest.json
+++ b/steps/19/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/20/package.json
+++ b/steps/20/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/20/package.json
+++ b/steps/20/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/20/ui5.yaml
+++ b/steps/20/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/20/ui5.yaml
+++ b/steps/20/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/20/webapp/index-cdn.html
+++ b/steps/20/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/20/webapp/index-cdn.html
+++ b/steps/20/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/20/webapp/manifest.json
+++ b/steps/20/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -59,6 +59,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/20/webapp/manifest.json
+++ b/steps/20/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/21/package.json
+++ b/steps/21/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/21/package.json
+++ b/steps/21/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/21/ui5.yaml
+++ b/steps/21/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/21/ui5.yaml
+++ b/steps/21/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/21/webapp/index-cdn.html
+++ b/steps/21/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/21/webapp/index-cdn.html
+++ b/steps/21/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/21/webapp/manifest.json
+++ b/steps/21/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -59,6 +59,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/21/webapp/manifest.json
+++ b/steps/21/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/22/package.json
+++ b/steps/22/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/22/package.json
+++ b/steps/22/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/22/ui5.yaml
+++ b/steps/22/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/22/ui5.yaml
+++ b/steps/22/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/22/webapp/index-cdn.html
+++ b/steps/22/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/22/webapp/index-cdn.html
+++ b/steps/22/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/22/webapp/manifest.json
+++ b/steps/22/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -59,6 +59,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/22/webapp/manifest.json
+++ b/steps/22/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/23/package.json
+++ b/steps/23/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/23/package.json
+++ b/steps/23/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/23/ui5.yaml
+++ b/steps/23/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/23/ui5.yaml
+++ b/steps/23/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/23/webapp/index-cdn.html
+++ b/steps/23/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/23/webapp/index-cdn.html
+++ b/steps/23/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/23/webapp/manifest.json
+++ b/steps/23/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -59,6 +59,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/23/webapp/manifest.json
+++ b/steps/23/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/24/package.json
+++ b/steps/24/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/24/package.json
+++ b/steps/24/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-tooling-transpile": "^3.7.1"

--- a/steps/24/ui5.yaml
+++ b/steps/24/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/24/ui5.yaml
+++ b/steps/24/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/24/webapp/index-cdn.html
+++ b/steps/24/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/24/webapp/index-cdn.html
+++ b/steps/24/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/24/webapp/manifest.json
+++ b/steps/24/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -59,6 +59,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/24/webapp/manifest.json
+++ b/steps/24/webapp/manifest.json
@@ -26,7 +26,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/25/README.md
+++ b/steps/25/README.md
@@ -51,7 +51,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/25/README.md
+++ b/steps/25/README.md
@@ -51,7 +51,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/25/package.json
+++ b/steps/25/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/25/package.json
+++ b/steps/25/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o index.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/25/ui5.yaml
+++ b/steps/25/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/25/ui5.yaml
+++ b/steps/25/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/25/webapp/index-cdn.html
+++ b/steps/25/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/25/webapp/index-cdn.html
+++ b/steps/25/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/25/webapp/manifest.json
+++ b/steps/25/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -67,6 +67,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/25/webapp/manifest.json
+++ b/steps/25/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/26/README.md
+++ b/steps/26/README.md
@@ -246,7 +246,7 @@ In case you prefer to continue with the local data, you should adjust the `start
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
+    "@types/openui5": "^1.132.0",
     "@ui5/cli": "^3.7.1",
     "typescript": "^5.2.2",	  
     "ui5-middleware-livereload": "^3.0.2",

--- a/steps/26/README.md
+++ b/steps/26/README.md
@@ -246,7 +246,7 @@ In case you prefer to continue with the local data, you should adjust the `start
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
+    "@types/openui5": "^1.131.0",
     "@ui5/cli": "^3.7.1",
     "typescript": "^5.2.2",	  
     "ui5-middleware-livereload": "^3.0.2",

--- a/steps/26/package.json
+++ b/steps/26/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/26/package.json
+++ b/steps/26/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/26/ui5.yaml
+++ b/steps/26/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/26/ui5.yaml
+++ b/steps/26/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/26/webapp/index-cdn.html
+++ b/steps/26/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/26/webapp/index-cdn.html
+++ b/steps/26/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/26/webapp/manifest.json
+++ b/steps/26/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -67,6 +67,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/26/webapp/manifest.json
+++ b/steps/26/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/26/webapp/test/mockServer-cdn.html
+++ b/steps/26/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/26/webapp/test/mockServer-cdn.html
+++ b/steps/26/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/27/package.json
+++ b/steps/27/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/27/package.json
+++ b/steps/27/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/27/ui5.yaml
+++ b/steps/27/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/27/ui5.yaml
+++ b/steps/27/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/27/webapp/index-cdn.html
+++ b/steps/27/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/27/webapp/index-cdn.html
+++ b/steps/27/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/27/webapp/manifest.json
+++ b/steps/27/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -67,6 +67,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/27/webapp/manifest.json
+++ b/steps/27/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/27/webapp/test/Test.cdn.qunit.html
+++ b/steps/27/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/27/webapp/test/Test.cdn.qunit.html
+++ b/steps/27/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/27/webapp/test/mockServer-cdn.html
+++ b/steps/27/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/27/webapp/test/mockServer-cdn.html
+++ b/steps/27/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/27/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/27/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/27/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/27/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/28/package.json
+++ b/steps/28/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/28/package.json
+++ b/steps/28/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/28/ui5.yaml
+++ b/steps/28/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/28/ui5.yaml
+++ b/steps/28/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/28/webapp/index-cdn.html
+++ b/steps/28/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/28/webapp/index-cdn.html
+++ b/steps/28/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/28/webapp/manifest.json
+++ b/steps/28/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -67,6 +67,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/28/webapp/manifest.json
+++ b/steps/28/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/28/webapp/test/Test.cdn.qunit.html
+++ b/steps/28/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/28/webapp/test/Test.cdn.qunit.html
+++ b/steps/28/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/28/webapp/test/mockServer-cdn.html
+++ b/steps/28/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/28/webapp/test/mockServer-cdn.html
+++ b/steps/28/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/28/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/28/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/28/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/28/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/29/package.json
+++ b/steps/29/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/29/package.json
+++ b/steps/29/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/29/ui5.yaml
+++ b/steps/29/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/29/ui5.yaml
+++ b/steps/29/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/29/webapp/index-cdn.html
+++ b/steps/29/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/29/webapp/index-cdn.html
+++ b/steps/29/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/29/webapp/manifest.json
+++ b/steps/29/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -67,6 +67,6 @@
                 "uri": "css/style.css"
               }
             ]
-        }      
+        }
     }
 }

--- a/steps/29/webapp/manifest.json
+++ b/steps/29/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/29/webapp/test/Test.cdn.qunit.html
+++ b/steps/29/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/29/webapp/test/Test.cdn.qunit.html
+++ b/steps/29/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/29/webapp/test/mockServer-cdn.html
+++ b/steps/29/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/29/webapp/test/mockServer-cdn.html
+++ b/steps/29/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/29/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/29/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/29/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/29/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/30/package.json
+++ b/steps/30/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/30/package.json
+++ b/steps/30/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/30/ui5.yaml
+++ b/steps/30/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/30/ui5.yaml
+++ b/steps/30/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/30/webapp/index-cdn.html
+++ b/steps/30/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/30/webapp/index-cdn.html
+++ b/steps/30/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/30/webapp/manifest.json
+++ b/steps/30/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/30/webapp/manifest.json
+++ b/steps/30/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}
@@ -67,7 +67,7 @@
                 "uri": "css/style.css"
               }
             ]
-        },    
+        },
         "routing": {
           "config": {
             "routerClass": "sap.m.routing.Router",

--- a/steps/30/webapp/test/Test.cdn.qunit.html
+++ b/steps/30/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/30/webapp/test/Test.cdn.qunit.html
+++ b/steps/30/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/30/webapp/test/mockServer-cdn.html
+++ b/steps/30/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/30/webapp/test/mockServer-cdn.html
+++ b/steps/30/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/30/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/30/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/30/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/30/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/31/package.json
+++ b/steps/31/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/31/package.json
+++ b/steps/31/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/31/ui5.yaml
+++ b/steps/31/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/31/ui5.yaml
+++ b/steps/31/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/31/webapp/index-cdn.html
+++ b/steps/31/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/31/webapp/index-cdn.html
+++ b/steps/31/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/31/webapp/manifest.json
+++ b/steps/31/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/31/webapp/manifest.json
+++ b/steps/31/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/31/webapp/test/Test.cdn.qunit.html
+++ b/steps/31/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/31/webapp/test/Test.cdn.qunit.html
+++ b/steps/31/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/31/webapp/test/mockServer-cdn.html
+++ b/steps/31/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/31/webapp/test/mockServer-cdn.html
+++ b/steps/31/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/31/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/31/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/31/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/31/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/32/package.json
+++ b/steps/32/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
-    "typescript": "^5.7.3",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
+    "typescript": "^5.7.2",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/32/package.json
+++ b/steps/32/package.json
@@ -8,9 +8,9 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
-    "typescript": "^5.7.2",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
+    "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",
     "ui5-middleware-serveframework": "^3.5.0",
     "ui5-middleware-simpleproxy": "^3.4.0",

--- a/steps/32/ui5.yaml
+++ b/steps/32/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/32/ui5.yaml
+++ b/steps/32/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/32/webapp/index-cdn.html
+++ b/steps/32/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/32/webapp/index-cdn.html
+++ b/steps/32/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/32/webapp/manifest.json
+++ b/steps/32/webapp/manifest.json
@@ -4,7 +4,7 @@
         "id": "ui5.walkthrough",
         "type": "application",
         "i18n": {
-            "bundleName": "ui5.walkthrough.i18n.i18n",  
+            "bundleName": "ui5.walkthrough.i18n.i18n",
             "supportedLocales": [
               ""
         ],
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/32/webapp/manifest.json
+++ b/steps/32/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/32/webapp/test/Test.cdn.qunit.html
+++ b/steps/32/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/32/webapp/test/Test.cdn.qunit.html
+++ b/steps/32/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/32/webapp/test/mockServer-cdn.html
+++ b/steps/32/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/32/webapp/test/mockServer-cdn.html
+++ b/steps/32/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/32/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/32/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/32/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/32/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/33/package.json
+++ b/steps/33/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/33/package.json
+++ b/steps/33/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/33/ui5.yaml
+++ b/steps/33/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/33/ui5.yaml
+++ b/steps/33/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/33/webapp/index-cdn.html
+++ b/steps/33/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/33/webapp/index-cdn.html
+++ b/steps/33/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/33/webapp/manifest.json
+++ b/steps/33/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/33/webapp/manifest.json
+++ b/steps/33/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/33/webapp/test/Test.cdn.qunit.html
+++ b/steps/33/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/33/webapp/test/Test.cdn.qunit.html
+++ b/steps/33/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/33/webapp/test/mockServer-cdn.html
+++ b/steps/33/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/33/webapp/test/mockServer-cdn.html
+++ b/steps/33/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/33/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/33/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/33/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/33/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/34/package.json
+++ b/steps/34/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/34/package.json
+++ b/steps/34/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/34/ui5.yaml
+++ b/steps/34/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/34/ui5.yaml
+++ b/steps/34/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/34/webapp/index-cdn.html
+++ b/steps/34/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/34/webapp/index-cdn.html
+++ b/steps/34/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/34/webapp/manifest.json
+++ b/steps/34/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/34/webapp/manifest.json
+++ b/steps/34/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/34/webapp/test/Test.cdn.qunit.html
+++ b/steps/34/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/34/webapp/test/Test.cdn.qunit.html
+++ b/steps/34/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/34/webapp/test/mockServer-cdn.html
+++ b/steps/34/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/34/webapp/test/mockServer-cdn.html
+++ b/steps/34/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/34/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/34/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/34/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/34/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/35/package.json
+++ b/steps/35/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/35/package.json
+++ b/steps/35/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/35/ui5.yaml
+++ b/steps/35/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/35/ui5.yaml
+++ b/steps/35/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/35/webapp/index-cdn.html
+++ b/steps/35/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/35/webapp/index-cdn.html
+++ b/steps/35/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/35/webapp/manifest.json
+++ b/steps/35/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/35/webapp/manifest.json
+++ b/steps/35/webapp/manifest.json
@@ -35,7 +35,7 @@
     },
     "sap.ui5": {
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/35/webapp/test/Test.cdn.qunit.html
+++ b/steps/35/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/35/webapp/test/Test.cdn.qunit.html
+++ b/steps/35/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/35/webapp/test/mockServer-cdn.html
+++ b/steps/35/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/35/webapp/test/mockServer-cdn.html
+++ b/steps/35/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/35/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/35/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/35/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/35/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/36/README.md
+++ b/steps/36/README.md
@@ -87,7 +87,7 @@ As we have just enabled the app to run in both modes depending on the devices ca
       "cozy": true
     },
     "dependencies": {
-        "minUI5Version": "1.120",
+        "minUI5Version": "1.131",
         "libs": {
             "sap.ui.core": {},
             "sap.m": {}

--- a/steps/36/README.md
+++ b/steps/36/README.md
@@ -87,7 +87,7 @@ As we have just enabled the app to run in both modes depending on the devices ca
       "cozy": true
     },
     "dependencies": {
-        "minUI5Version": "1.131",
+        "minUI5Version": "1.132",
         "libs": {
             "sap.ui.core": {},
             "sap.m": {}

--- a/steps/36/package.json
+++ b/steps/36/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/36/package.json
+++ b/steps/36/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/36/ui5.yaml
+++ b/steps/36/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/36/ui5.yaml
+++ b/steps/36/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/36/webapp/index-cdn.html
+++ b/steps/36/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/36/webapp/index-cdn.html
+++ b/steps/36/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/36/webapp/manifest.json
+++ b/steps/36/webapp/manifest.json
@@ -39,7 +39,7 @@
           "cozy": true
       },
       "dependencies": {
-          "minUI5Version": "1.131",
+          "minUI5Version": "1.132",
           "libs": {
               "sap.ui.core": {},
               "sap.m": {}

--- a/steps/36/webapp/manifest.json
+++ b/steps/36/webapp/manifest.json
@@ -39,7 +39,7 @@
           "cozy": true
       },
       "dependencies": {
-          "minUI5Version": "1.120",
+          "minUI5Version": "1.131",
           "libs": {
               "sap.ui.core": {},
               "sap.m": {}

--- a/steps/36/webapp/test/Test.cdn.qunit.html
+++ b/steps/36/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/36/webapp/test/Test.cdn.qunit.html
+++ b/steps/36/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/36/webapp/test/mockServer-cdn.html
+++ b/steps/36/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/36/webapp/test/mockServer-cdn.html
+++ b/steps/36/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/36/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/36/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/36/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/36/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/37/package.json
+++ b/steps/37/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/37/package.json
+++ b/steps/37/package.json
@@ -8,8 +8,8 @@
     "start": "ui5 serve -o test/mockServer.html"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "ui5-middleware-livereload": "^3.1.0",

--- a/steps/37/ui5.yaml
+++ b/steps/37/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/37/ui5.yaml
+++ b/steps/37/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/37/webapp/index-cdn.html
+++ b/steps/37/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/37/webapp/index-cdn.html
+++ b/steps/37/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/37/webapp/manifest.json
+++ b/steps/37/webapp/manifest.json
@@ -39,7 +39,7 @@
             "cozy": true
         },
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/37/webapp/manifest.json
+++ b/steps/37/webapp/manifest.json
@@ -39,7 +39,7 @@
             "cozy": true
         },
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/37/webapp/test/Test.cdn.qunit.html
+++ b/steps/37/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/37/webapp/test/Test.cdn.qunit.html
+++ b/steps/37/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/37/webapp/test/mockServer-cdn.html
+++ b/steps/37/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/37/webapp/test/mockServer-cdn.html
+++ b/steps/37/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/37/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/37/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/37/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/37/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/38/README.md
+++ b/steps/38/README.md
@@ -34,7 +34,7 @@ Now we create a production-ready version of our OpenUI5 application that can be 
     "build": "ui5 build --all --clean-dest"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
+    "@types/openui5": "^1.132.0",
     "@ui5/cli": "^3.7.1",
     "@ui5/ts-interface-generator": "^0.8.1",
     "typescript": "^5.2.2",
@@ -76,7 +76,7 @@ To actually use the newly added web server, we have to add a new script to our `
     "serve-dist": "ws --compress -d dist --open"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
+    "@types/openui5": "^1.132.0",
     "@ui5/cli": "^3.7.1",
     "@ui5/ts-interface-generator": "^0.8.1",
     "typescript": "^5.2.2",

--- a/steps/38/README.md
+++ b/steps/38/README.md
@@ -34,7 +34,7 @@ Now we create a production-ready version of our OpenUI5 application that can be 
     "build": "ui5 build --all --clean-dest"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
+    "@types/openui5": "^1.131.0",
     "@ui5/cli": "^3.7.1",
     "@ui5/ts-interface-generator": "^0.8.1",
     "typescript": "^5.2.2",
@@ -76,7 +76,7 @@ To actually use the newly added web server, we have to add a new script to our `
     "serve-dist": "ws --compress -d dist --open"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
+    "@types/openui5": "^1.131.0",
     "@ui5/cli": "^3.7.1",
     "@ui5/ts-interface-generator": "^0.8.1",
     "typescript": "^5.2.2",

--- a/steps/38/package.json
+++ b/steps/38/package.json
@@ -10,8 +10,8 @@
     "serve-dist": "ws --compress -d dist --open"
   },
   "devDependencies": {
-    "@types/openui5": "^1.131.0",
-    "@ui5/cli": "^4.0.12",
+    "@types/openui5": "^1.132.0",
+    "@ui5/cli": "^4.0.13",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "local-web-server": "^5.4.0",

--- a/steps/38/package.json
+++ b/steps/38/package.json
@@ -10,8 +10,8 @@
     "serve-dist": "ws --compress -d dist --open"
   },
   "devDependencies": {
-    "@types/openui5": "^1.120.0",
-    "@ui5/cli": "^4.0.13",
+    "@types/openui5": "^1.131.0",
+    "@ui5/cli": "^4.0.12",
     "@ui5/ts-interface-generator": "^0.9.0",
     "typescript": "^5.7.3",
     "local-web-server": "^5.4.0",

--- a/steps/38/ui5.yaml
+++ b/steps/38/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.129.0"
+  version: "1.131.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/38/ui5.yaml
+++ b/steps/38/ui5.yaml
@@ -4,7 +4,7 @@ metadata:
 type: application
 framework:
   name: OpenUI5
-  version: "1.131.1"
+  version: "1.132.1"
   libraries:
     - name: sap.m
     - name: sap.ui.core

--- a/steps/38/webapp/index-cdn.html
+++ b/steps/38/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/38/webapp/index-cdn.html
+++ b/steps/38/webapp/index-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/38/webapp/manifest.json
+++ b/steps/38/webapp/manifest.json
@@ -39,7 +39,7 @@
             "cozy": true
         },
         "dependencies": {
-            "minUI5Version": "1.131",
+            "minUI5Version": "1.132",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/38/webapp/manifest.json
+++ b/steps/38/webapp/manifest.json
@@ -39,7 +39,7 @@
             "cozy": true
         },
         "dependencies": {
-            "minUI5Version": "1.120",
+            "minUI5Version": "1.131",
             "libs": {
                 "sap.ui.core": {},
                 "sap.m": {}

--- a/steps/38/webapp/test/Test.cdn.qunit.html
+++ b/steps/38/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/38/webapp/test/Test.cdn.qunit.html
+++ b/steps/38/webapp/test/Test.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/runTest.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/runTest.js"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"
 		}'

--- a/steps/38/webapp/test/mockServer-cdn.html
+++ b/steps/38/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/38/webapp/test/mockServer-cdn.html
+++ b/steps/38/webapp/test/mockServer-cdn.html
@@ -5,7 +5,7 @@
 	<title>UI5 TypeScript Walkthrough - Mockserver Test Page</title>
 	<script
 		id="sap-ui-bootstrap"
-		src="https://sdk.openui5.org/1.129.0/resources/sap-ui-core.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap-ui-core.js"
 		data-sap-ui-theme="sap_horizon"
 		data-sap-ui-compat-version="edge"
 		data-sap-ui-async="true"

--- a/steps/38/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/38/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.129.0/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"

--- a/steps/38/webapp/test/testsuite.cdn.qunit.html
+++ b/steps/38/webapp/test/testsuite.cdn.qunit.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<script
-		src="https://sdk.openui5.org/1.131.1/resources/sap/ui/test/starter/createSuite.js"
+		src="https://sdk.openui5.org/1.132.1/resources/sap/ui/test/starter/createSuite.js"
 		data-sap-ui-testsuite="test-resources/ui5/walkthrough/testsuite.cdn.qunit"
 		data-sap-ui-resource-roots='{
 			"test-resources.ui5.walkthrough": "./"


### PR DESCRIPTION
- Upgrade UI5 version to 1.132.1
- Upgrade minVersion of UI5 to 1.132
- Upgrade @types/openui5 to 1.132.0 (Currently, for @types/openui5 no patch releases are created)