### PR TITLE
Add core namespace to XML view examples

### DIFF
--- a/packages/walkthrough/steps/24/README.md
+++ b/packages/walkthrough/steps/24/README.md
@@ -40,6 +40,7 @@ We add a declarative sorter to the binding syntax of the list control. Therefore
 <mvc:View
    controllerName="ui5.walkthrough.controller.InvoiceList"
    xmlns="sap.m"
+   xmlns:core="sap.ui.core"
    xmlns:mvc="sap.ui.core.mvc">
    <List
       id="invoiceList"
@@ -69,6 +70,7 @@ As with the sorter, no further action is required. The list and the data binding
 <mvc:View
    controllerName="ui5.walkthrough.controller.InvoiceList"
    xmlns="sap.m"
+   xmlns:core="sap.ui.core"
    xmlns:mvc="sap.ui.core.mvc">
    <List
       id="invoiceList"


### PR DESCRIPTION
Added `xmlns:core="sap.ui.core"` to `InvoiceList.view.xml` otherwise the UI doesn't render (empty page).