### PR TITLE
Add xmlns:core to XML example in README

### DIFF
--- a/packages/walkthrough/steps/34/README.md
+++ b/packages/walkthrough/steps/34/README.md
@@ -104,6 +104,7 @@ Instead of the `ObjectListItem` that we had before, we will now split the inform
 <mvc:View
 	controllerName="ui5.walkthrough.controller.InvoiceList"
 	xmlns="sap.m"
+	xmlns:core="sap.ui.core"
 	xmlns:mvc="sap.ui.core.mvc">
 	<Table
 		id="invoiceList"


### PR DESCRIPTION
This pull request makes a small update to the XML view file by adding the `sap.ui.core` namespace as `core`. This change ensures that core UI5 controls and features can be referenced in the view.

- Added the `xmlns:core="sap.ui.core"` namespace declaration to the XML view to enable usage of core UI5 controls.