### PR TITLE
build: preserve handlebars placeholders in code snippets

### DIFF
--- a/tools/builder/prepare-gh-pages.js
+++ b/tools/builder/prepare-gh-pages.js
@@ -70,6 +70,24 @@ function removeTSfromUI5YAML(ui5yaml) {
 	mkdirSync(join(cwd, "dist"), { recursive: true });
 
 	console.log(`👉 Copying root README.md...`);
+	function escapeCodeBlocks(content) {
+		// Jekyll/Liquid (used by GitHub Pages) interprets `{{ ... }}` and `{% ... %}`
+		// inside the markdown. Code snippets (fenced blocks and inline code) often
+		// contain handlebars-style placeholders like `{{appTitle}}` that must be
+		// preserved verbatim. Wrap them in `{% raw %}` / `{% endraw %}` so Liquid
+		// leaves them untouched.
+		// Fenced code blocks (``` ... ``` or ~~~ ... ~~~).
+		content = content.replace(/(^|\n)(```|~~~)([^\n]*)\n([\s\S]*?)\n\2(?=\n|$)/g,
+			(match, lead, fence, info, body) => `${lead}{% raw %}\n${fence}${info}\n${body}\n${fence}\n{% endraw %}`);
+		// Inline code spans (single or double backticks) on a single line.
+		content = content.replace(/(`+)(?!`)([^\n`][^\n]*?)\1/g, (match, ticks, body) => {
+			if (!body.includes("{{") && !body.includes("{%")) {
+				return match;
+			}
+			return `{% raw %}${ticks}${body}${ticks}{% endraw %}`;
+		});
+		return content;
+	}
 	function rewriteLinks(file) {
 		let permalink = file.split("dist/")[1].replace(".md", ".html");
 		const title = "UI5 Tutorials";
@@ -77,6 +95,7 @@ function removeTSfromUI5YAML(ui5yaml) {
 		content = content.replace(/README\.md/g, "index.html");
 		content = content.replace(/\.\/packages\//g, "./");
 		content = content.replace(/\[LICENSE\]\([\.\/\w]*\)/g, "[LICENSE](https://github.com/UI5/tutorials/blob/-/LICENSE)");
+		content = escapeCodeBlocks(content);
 		writeFileSync(file, content, { encoding: "utf8" });
 	}
 


### PR DESCRIPTION
## Problem

The published READMEs under `dist/<tutorial>/build/<step>/README.md` are rendered by GitHub Pages via Jekyll/Liquid. Liquid uses the same `{{ ... }}` / `{% ... %}` syntax that several tutorial code snippets need to display verbatim — most notably the UI5 i18n placeholders `{{appTitle}}` and `{{appDescription}}` in `manifest.json` examples (e.g. [walkthrough/steps/10](packages/walkthrough/steps/10/README.md#L116-L117)). Without escaping, Liquid silently replaces them with empty strings on the published page.

## Fix

Add an `escapeCodeBlocks` helper in [tools/builder/prepare-gh-pages.js](tools/builder/prepare-gh-pages.js) and call it from `rewriteLinks()` before each README is written to `dist/`:

- Fenced code blocks (`````` or `~~~`) get a surrounding `{% raw %}` / `{% endraw %}` pair.
- Inline backtick spans get the same treatment **only** when they actually contain `{{` or `{%`, to keep the output minimal.

The downloadable source copies under `dist/<tutorial>/steps/` (which are zipped and offered for download) are **not** touched, so unzipped tutorial projects keep their original UI5 i18n placeholders intact.

## Verification

After running `npm run build`:
- [dist/walkthrough/build/10/README.md](dist/walkthrough/build/10/README.md) — every fenced block (including the JSON one with `{{appTitle}}`) is now wrapped in `{% raw %}` / `{% endraw %}`.
- [dist/walkthrough/steps/10/README.md](dist/walkthrough/steps/10/README.md) — unchanged verbatim copy used for the downloadable zip.
