### PR TITLE
build: escape handlebars in step source README.md copies

### DIFF
--- a/tools/builder/prepare-gh-pages.js
+++ b/tools/builder/prepare-gh-pages.js
@@ -209,6 +209,10 @@ function removeTSfromUI5YAML(ui5yaml) {
 				} else if(file.endsWith(".yaml")) {
 					const ui5yaml = removeTSfromUI5YAML(yaml.load(readFileSync(source, { encoding: "utf8" })));
 					writeFileSync(target, yaml.dump(ui5yaml));
+				} else if (file.endsWith("README.md")) {
+					let content = escapeCodeBlocks(readFileSync(source, { encoding: "utf8"}));
+					mkdirSync(dirname(target), { recursive: true });
+					writeFileSync(target, content, { encoding: "utf8" });
 				} else if (file !== "tsconfig.json") {
 					mkdirSync(dirname(target), { recursive: true });
 					copyFileSync(source, target);


### PR DESCRIPTION
## Why

The earlier fix in #284 wrapped `{{ ... }}` / `{% ... %}` placeholders in fenced code blocks and inline code spans, but only when producing the rendered HTML pages under `dist/<tutorial>/build/<step>/README.md`.

The README files copied alongside the **step source code** under `dist/<tutorial>/steps/<step>/README.md` were left untouched and still went through Jekyll/Liquid as-is — so placeholders like `{{appTitle}}` and `{{appDescription}}` were stripped on the published site for that copy as well.

## What

Run the README files copied next to step sources through `escapeCodeBlocks()` so both rendering paths preserve the handlebars placeholders verbatim.