### PR TITLE
ci(renovate): Ignore updates for package @types/qunit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
 		"github>ui5/renovate-config:lts#v1.2.1"
 	],
 	"ignorePresets": [":ignoreModulesAndTests"],
+	"ignoreDeps": ["node", "npm", "@types/qunit"],
 	"minimumReleaseAge": "3 days",
 	"rangeStrategy": "pin",
 	"prCreation": "immediate",
@@ -42,13 +43,6 @@
 			"schedule": [
 				"* 8-16 * * 1"
 			]
-		},
-		{
-			"matchPackageNames": [
-				"node",
-				"npm"
-			],
-			"enabled": false
 		},
 		{
 			"matchDepNames": [


### PR DESCRIPTION
- Move disabled packages rules to global "ignoreDeps" list to make it easier to add new packages to ignore in the future.
- Add @types/qunit to the "ignoreDeps" list to not create PRs for this package as UI5 ships a fixed version of QUnit.
