### PR TITLE
fix(tutorials): drop title attr from step nav links so GitHub Pages resolves them

### DIFF
--- a/packages/databinding/steps/01/README.md
+++ b/packages/databinding/steps/01/README.md
@@ -215,7 +215,7 @@ server:
 
 ***
 
-**Next:** [Step 2: Creating a Model](../02/README.md "In this step, we create a model. It serves as a container for the data your application operates on.")
+**Next:** [Step 2: Creating a Model](../02/README.md)
 
 ***
 

--- a/packages/databinding/steps/02/README.md
+++ b/packages/databinding/steps/02/README.md
@@ -86,9 +86,9 @@ The text that is displayed on the UI is still hard-coded and not taken from the 
 
 ***
 
-**Next:** [Step 3: Create Property Binding](../03/README.md "Although there is no visible difference, the text on the screen is now derived from model data.")
+**Next:** [Step 3: Create Property Binding](../03/README.md)
 
-**Previous:** [Step 1: No Data Binding](../01/README.md "In this step, we create a basic application and simply place some text on the screen using a standard sap.m.Text control.")
+**Previous:** [Step 1: No Data Binding](../01/README.md)
 
 ***
 

--- a/packages/databinding/steps/03/README.md
+++ b/packages/databinding/steps/03/README.md
@@ -40,9 +40,9 @@ Assign the `text` property of the `sap.m.Text` control to the value `{/greetingT
 
 ***
 
-**Next:** [Step 4: Two-Way Data Binding](../04/README.md "In the examples we've looked at so far, we've displayed the value of a model property using a read-only field.")
+**Next:** [Step 4: Two-Way Data Binding](../04/README.md)
 
-**Previous:** [Step 2: Creating a Model](../02/README.md "In this step, we create a model.")
+**Previous:** [Step 2: Creating a Model](../02/README.md)
 
 ***
 

--- a/packages/databinding/steps/04/README.md
+++ b/packages/databinding/steps/04/README.md
@@ -100,9 +100,9 @@ Two things are happening here:
 
 ***
 
-**Next:** [Step 5: One-Way Data Binding](../05/README.md "Unlike the two-way binding behavior we've seen, one-way data binding is also possible.")
+**Next:** [Step 5: One-Way Data Binding](../05/README.md)
 
-**Previous:** [Step 3: Create Property Binding](../03/README.md "Although there is no visible difference, the text on the screen is now derived from model data.")
+**Previous:** [Step 3: Create Property Binding](../03/README.md)
 
 ***
 

--- a/packages/databinding/steps/05/README.md
+++ b/packages/databinding/steps/05/README.md
@@ -90,6 +90,6 @@ If you wish to alter the binding mode, you've got two options:
 
 ***
 
-**Next:** [Step 6: Resource Models](../06/README.md "Business applications often require language-specific \(translatable\) text used as labels and descriptions on the user interface.")
+**Next:** [Step 6: Resource Models](../06/README.md)
 
-**Previous:** [Step 4: Two-Way Data Binding](../04/README.md "In the examples we've looked at so far, we've displayed the value of a model property using a read-only field.")
+**Previous:** [Step 4: Two-Way Data Binding](../04/README.md)

--- a/packages/databinding/steps/06/README.md
+++ b/packages/databinding/steps/06/README.md
@@ -199,9 +199,9 @@ You can use multiple model instances by using different model names. The model n
 
 ***
 
-**Next:** [Step 7: \(Optional\) Resource Bundles and Multiple Languages](../07/README.md "Resource bundles exist to enable an app to run in multiple languages without the need to change any code.")
+**Next:** [Step 7: \(Optional\) Resource Bundles and Multiple Languages](../07/README.md)
 
-**Previous:** [Step 5: One-Way Data Binding](../05/README.md "Unlike the two-way binding behavior we've seen, one-way data binding is also possible.")
+**Previous:** [Step 5: One-Way Data Binding](../05/README.md)
 
 ***
 

--- a/packages/databinding/steps/07/README.md
+++ b/packages/databinding/steps/07/README.md
@@ -53,9 +53,9 @@ To check the result, append the `sap-language=DE` URL parameter to the URL in yo
 
 ***
 
-**Next:** [Step 8: Binding Paths: Accessing Properties in Hierarchically Structured Models](../08/README.md "Let's explore how to reference fields in a hierarchically structured model object.")
+**Next:** [Step 8: Binding Paths: Accessing Properties in Hierarchically Structured Models](../08/README.md)
 
-**Previous:** [Step 6: Resource Models](../06/README.md "Business applications often require language-specific (translatable) text used as labels and descriptions on the user interface.")
+**Previous:** [Step 6: Resource Models](../06/README.md)
 
 ***
 

--- a/packages/databinding/steps/08/README.md
+++ b/packages/databinding/steps/08/README.md
@@ -123,9 +123,9 @@ panel2HeaderText=Adressdetails
 
 ***
 
-**Next:** [Step 9: Formatting Values](../09/README.md "We'd also like to provide our users with a way of contacting Harry Hawk, so we're adding a link that sends an e-mail to Harry.")
+**Next:** [Step 9: Formatting Values](../09/README.md)
 
-**Previous:** [Step 7: \(Optional\) Resource Bundles and Multiple Languages](../07/README.md "Resource bundles exist to enable an app to run in multiple languages without the need to change any code.")
+**Previous:** [Step 7: \(Optional\) Resource Bundles and Multiple Languages](../07/README.md)
 
 ***
 

--- a/packages/databinding/steps/09/README.md
+++ b/packages/databinding/steps/09/README.md
@@ -161,9 +161,9 @@ mailBody=Wie geht es dir?
 
 ***
 
-**Next:** [Step 10: Property Formatting Using Data Types](../10/README.md "OpenUI5 offers a set of simple data types, including Boolean, Currency, Date and Float.")
+**Next:** [Step 10: Property Formatting Using Data Types](../10/README.md)
 
-**Previous:** [Step 8: Binding Paths: Accessing Properties in Hierarchically Structured Models](../08/README.md "In Step 6, we stated that the fields in a resource model are arranged in a flat structure; in other words, there is no hierarchy of properties.")
+**Previous:** [Step 8: Binding Paths: Accessing Properties in Hierarchically Structured Models](../08/README.md)
 
 ***
 

--- a/packages/databinding/steps/10/README.md
+++ b/packages/databinding/steps/10/README.md
@@ -133,9 +133,9 @@ salesAmount=Verk\u00e4ufe bis zum heutigen Datum
 
 ***
 
-**Next:** [Step 11: Validation Using `sap/ui/core/Messaging`](../11/README.md "Up to this point, we've created a currency field that formats itself correctly. The currency data type can also validate user input to ensure it meets currency requirements.")
+**Next:** [Step 11: Validation Using `sap/ui/core/Messaging`](../11/README.md)
 
-**Previous:** [Step 9: Formatting Values](../09/README.md "We'd also like to provide our users with a way of contacting Harry Hawk, so we're adding a link that sends an e-mail to Harry.")
+**Previous:** [Step 9: Formatting Values](../09/README.md)
 
 ***
 

--- a/packages/databinding/steps/11/README.md
+++ b/packages/databinding/steps/11/README.md
@@ -60,9 +60,9 @@ However, the error message only displays when that particular field is in focus:
 
 ***
 
-**Next:** [Step 12: Aggregation Binding Using Templates](../12/README.md "Aggregation binding, also known as list binding, lets a control bind to a list within the model data.")
+**Next:** [Step 12: Aggregation Binding Using Templates](../12/README.md)
 
-**Previous:** [Step 10: Property Formatting Using Data Types](../10/README.md "OpenUI5 offers a set of simple data types, including Boolean, Currency, Date and Float.")
+**Previous:** [Step 10: Property Formatting Using Data Types](../10/README.md)
 
 ***
 

--- a/packages/databinding/steps/12/README.md
+++ b/packages/databinding/steps/12/README.md
@@ -294,9 +294,9 @@ stockValue=Lagerbestand Wert
 
 ***
 
-**Next:** [Step 13: Element Binding](../13/README.md "Now, let's do something with that newly generated list.")
+**Next:** [Step 13: Element Binding](../13/README.md)
 
-**Previous:** [Step 11: Validation Using `sap/ui/core/Messaging`](../11/README.md "Up to this point, we've created a currency field that formats itself correctly.")
+**Previous:** [Step 11: Validation Using `sap/ui/core/Messaging`](../11/README.md)
 
 ***
 

--- a/packages/databinding/steps/13/README.md
+++ b/packages/databinding/steps/13/README.md
@@ -201,9 +201,9 @@ Now, you can click on an element in the list and view its details in the panel b
 
 ***
 
-**Next:** [Step 14: Expression Binding](../14/README.md "An expression binding lets you display a calculated value on the screen, which is derived from values found in a model object.")
+**Next:** [Step 14: Expression Binding](../14/README.md)
 
-**Previous:** [Step 12: Aggregation Binding Using Templates](../12/README.md "Aggregation binding, also known as list binding, lets a control bind to a list within the model data.")
+**Previous:** [Step 12: Aggregation Binding Using Templates](../12/README.md)
 
 ***
 

--- a/packages/databinding/steps/14/README.md
+++ b/packages/databinding/steps/14/README.md
@@ -138,9 +138,9 @@ The ampersand \(`&`\) character also has a high-priority meaning to the XML pars
 
 ***
 
-**Next:** [Step 15: Aggregation Binding Using a Factory Function](../15/README.md "Instead of using a single hard-coded template control, we now opt for a factory function to generate different controls based on the data received at runtime.")
+**Next:** [Step 15: Aggregation Binding Using a Factory Function](../15/README.md)
 
-**Previous:** [Step 13: Element Binding](../13/README.md "Now, let's do something with that newly generated list.")
+**Previous:** [Step 13: Element Binding](../13/README.md)
 
 ***
 

--- a/packages/databinding/steps/15/README.md
+++ b/packages/databinding/steps/15/README.md
@@ -236,7 +236,7 @@ Congratulations! You've completed the Data Binding tutorial.
 
 ***
 
-**Previous:** [Step 14: Expression Binding](../14/README.md "An expression binding lets you display a calculated value on the screen, which is derived from values found in a model object.")
+**Previous:** [Step 14: Expression Binding](../14/README.md)
 
 ***
 

--- a/packages/quickstart/steps/01/README.md
+++ b/packages/quickstart/steps/01/README.md
@@ -342,7 +342,7 @@ npm start
 
 ***
 
-**Next:** [Step 2: Steady...](../02/README.md "Before we can do something with UI5, we need to laod and initialize it. This process of loading and initializing UI5 is called bootstrapping. Once this bootstrapping is finished, we simply display an alert.")
+**Next:** [Step 2: Steady...](../02/README.md)
 
 ***
 

--- a/packages/quickstart/steps/02/README.md
+++ b/packages/quickstart/steps/02/README.md
@@ -111,7 +111,7 @@ sap.ui.define([
 You can see a title bar and a blue button that reacts to your input. Congratulations, you have created our very first app.
 
 
-**Next:** [Step 3: Go!](../03/README.md "Before we can do something with UI5, we need to laod and initialize it. This process of loading and initializing UI5 is called bootstrapping. Once this bootstrapping is finished, we simply display an alert.")
+**Next:** [Step 3: Go!](../03/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/01/README.md
+++ b/packages/walkthrough/steps/01/README.md
@@ -161,7 +161,7 @@ This will open a new browser window hosting your newly created `index.html`.
 
 ***
 
-**Next:** [Step 2: Bootstrap](../02/README.md "Before we can do something with UI5, we need to laod and initialize it. This process of loading and initializing UI5 is called bootstrapping. Once this bootstrapping is finished, we simply display an alert.")
+**Next:** [Step 2: Bootstrap](../02/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/02/README.md
+++ b/packages/walkthrough/steps/02/README.md
@@ -248,9 +248,9 @@ Now you can benefit from live reload on changes and built framework resources at
 
 ***
 
-**Next:** [Step 3: Controls](../03/README.md "Now it's time to build our first little UI by replacing the Hello World text in the HTML body by the OpenUI5 control sap.m.Text. In the beginning, we will use the TypeScript control API to set up the UI, the control instance is then placed into the HTML body‚")
+**Next:** [Step 3: Controls](../03/README.md)
 
-**Previous:** [Step 1: Hello World!](../01/README.md "As you know OpenUI5 is all about HTML5. Let's get started with building a first Hello World with only HTML. In addition we will initialize the UI5 CLI, so we can benefit from it from the beginning.")
+**Previous:** [Step 1: Hello World!](../01/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/03/README.md
+++ b/packages/walkthrough/steps/03/README.md
@@ -134,9 +134,9 @@ ui5 add sap.m
 
 ***
 
-**Next:** [Step 4: XML Views](../04/README.md "Putting all our UI into the index.html file will very soon result in a messy setup and there is quite a bit of work ahead of us. So let’s do a first modularization by putting the sap/m/Text control into a dedicated view.")
+**Next:** [Step 4: XML Views](../04/README.md)
 
-**Previous:** [Step 2: Bootstrap](../02/README.md "Before we can do something with OpenUI5, we need to load and initialize it. This process of loading and initializing OpenUI5 is called bootstrapping. Once this bootstrapping is finished, we simply display an alert.")
+**Previous:** [Step 2: Bootstrap](../02/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/04/README.md
+++ b/packages/walkthrough/steps/04/README.md
@@ -104,9 +104,9 @@ We have now embed our app view to the body of the HTML document.
 
 ***
 
-**Next:** [Step 5: Controllers](../05/README.md "In this step, we replace the text with a button and show the Hello World message when the button is pressed. The handling of the button's press event is implemented in the controller of the view.")
+**Next:** [Step 5: Controllers](../05/README.md)
 
-**Previous:** [Step 3: Controls](../03/README.md "Now it's time to build our first little UI by replacing the Hello World text in the HTML body by the OpenUI5 control sap.m.Text. In the beginning, we will use the TypeScript control AOI to set up the UI, the control instance is then placed into the HTML body.")
+**Previous:** [Step 3: Controls](../03/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/05/README.md
+++ b/packages/walkthrough/steps/05/README.md
@@ -106,9 +106,9 @@ A view does not necessarily need an explicitly assigned controller. You do not h
 
 ***
 
-**Next:** [Step 6: Modules](../06/README.md "In OpenUI5, resources are often referred to as modules. In this step, we replace the alert from the last exercise with a proper Message Toast from the `sap.m` library.")
+**Next:** [Step 6: Modules](../06/README.md)
 
-**Previous:** [Step 4: XML Views](../04/README.md "Putting all our UI into the index.html file will very soon result in a messy setup and there is quite a bit of work ahead of us. So let’s do a first modularization by putting the sap/m/Text control into a dedicated view.")
+**Previous:** [Step 4: XML Views](../04/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/06/README.md
+++ b/packages/walkthrough/steps/06/README.md
@@ -67,9 +67,9 @@ For now, the message toast just displays a static "Hello World" message. We will
 
 ***
 
-**Next:** [Step 7: JSON Model](../07/README.md "Now that we have set up the view and controller, it’s about time to think about the M in MVC.")
+**Next:** [Step 7: JSON Model](../07/README.md)
 
-**Previous:** [Step 5: Controllers](../05/README.md "In this step, we replace the text with a button and show the Hello World message when the button is pressed. The handling of the button's press event is implemented in the controller of the view.")
+**Previous:** [Step 5: Controllers](../05/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/07/README.md
+++ b/packages/walkthrough/steps/07/README.md
@@ -126,9 +126,9 @@ In addition to this, we create a greeting message. We combine the static text "H
 
 ***
 
-**Next:** [Step 8: Translatable Texts](../08/README.md "In this step we move the texts of our UI to a separate resource file.")
+**Next:** [Step 8: Translatable Texts](../08/README.md)
 
-**Previous:** [Step 6: Modules](../06/README.md "In OpenUI5, resources are often referred to as modules. In this step, we replace the alert from the last exercise with a proper Message Toast from the `sap.m` library.")
+**Previous:** [Step 6: Modules](../06/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/08/README.md
+++ b/packages/walkthrough/steps/08/README.md
@@ -178,9 +178,9 @@ A resource bundle is a flat structure, therefore the preceding slash \(/\) can b
 
 ***
 
-**Next:** [Step 9: Component Configuration](../09/README.md "After we have introduced all three parts of the Model-View-Controller \(MVC\) concept, we now come to another important structural aspect of OpenUI5.")
+**Next:** [Step 9: Component Configuration](../09/README.md)
 
-**Previous:** [Step 7: JSON Model](../07/README.md "Now that we have set up the view and controller, it’s about time to think about the M in MVC.")
+**Previous:** [Step 7: JSON Model](../07/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/09/README.md
+++ b/packages/walkthrough/steps/09/README.md
@@ -246,9 +246,9 @@ sap.ui.define(["sap/ui/core/ComponentContainer"], function (ComponentContainer) 
 
 ***
 
-**Next:** [Step 10: Manifest (Descriptor for Applications)](../10/README.md "All application-specific configuration settings will now further be put into the manifest. This clearly separates the application coding from the configuration settings and makes our app even more flexible.")
+**Next:** [Step 10: Manifest (Descriptor for Applications)](../10/README.md)
 
-**Previous:** [Step 8: Translatable Texts](../08/README.md "In this step we move the texts of our UI to a separate resource file.")
+**Previous:** [Step 8: Translatable Texts](../08/README.md)
 
 &nbsp;
 ***

--- a/packages/walkthrough/steps/10/README.md
+++ b/packages/walkthrough/steps/10/README.md
@@ -267,9 +267,9 @@ We can now delete our `index.ts/.js` file, because our component is now initiate
 
 ***
 
-**Next:** [Step 11: Pages and Panels](../11/README.md "After all the work on the app structure it’s time to improve the look of our app. We will use two controls from the sap.m library to add a bit more bling to our UI. You will also learn about control aggregations in this step.")
+**Next:** [Step 11: Pages and Panels](../11/README.md)
 
-**Previous:** [Step 9: Component Configuration](../09/README.md "After we have introduced all three parts of the Model-View-Controller \(MVC\) concept, we now come to another important structural aspect of OpenUI5.")
+**Previous:** [Step 9: Component Configuration](../09/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/11/README.md
+++ b/packages/walkthrough/steps/11/README.md
@@ -92,9 +92,9 @@ The `App` control does the following important things for us:
 
 ***
 
-**Next:** [Step 12: Shell Control as Container](../12/README.md "Now we use a shell control as container for our app and use it as our new root element. The shell takes care of visual adaptation of the application to the device’s screen size by introducing a so-called letterbox on desktop screens.")
+**Next:** [Step 12: Shell Control as Container](../12/README.md)
 
-**Previous:** [Step 10: Manifest (Descriptor for Applications)](../10/README.md "All application-specific configuration settings will now further be put into the manifest. This clearly separates the application coding from the configuration settings and makes our app even more flexible.")
+**Previous:** [Step 10: Manifest (Descriptor for Applications)](../10/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/12/README.md
+++ b/packages/walkthrough/steps/12/README.md
@@ -67,9 +67,9 @@ There are further options to customize the shell, like setting a custom backgrou
 
 ***
 
-**Next:** [Step 13: Margins and Paddings](../13/README.md "Our app content is still glued to the corners of the letterbox. To fine-tune our layout, we can add margins and paddings to the controls that we added in the previous step.")
+**Next:** [Step 13: Margins and Paddings](../13/README.md)
 
-**Previous:** [Step 11: Pages and Panels](../11/README.md "After all the work on the app structure it’s time to improve the look of our app. We will use two controls from the sap.m library to add a bit more &quot;bling&quot; to our UI. You will also learn about control aggregations in this step.")
+**Previous:** [Step 11: Pages and Panels](../11/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/13/README.md
+++ b/packages/walkthrough/steps/13/README.md
@@ -80,9 +80,9 @@ To format the output text individually, we remove the description from the input
 
 ***
 
-**Next:** [Step 14: Custom CSS and Theme Colors](../14/README.md "Sometimes we need to define some more fine-granular layouts and this is when we can use the flexibility of CSS by adding custom style classes to controls and style them as we like.")
+**Next:** [Step 14: Custom CSS and Theme Colors](../14/README.md)
 
-**Previous:** [Step 12: Shell Control as Container](../12/README.md "Now we use a shell control as container for our app and use it as our new root element. The shell takes care of visual adaptation of the application to the device’s screen size by introducing a so-called letterbox on desktop screens.")
+**Previous:** [Step 12: Shell Control as Container](../12/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/14/README.md
+++ b/packages/walkthrough/steps/14/README.md
@@ -133,9 +133,9 @@ The actual color now depends on the selected theme which ensures that the color 
 **Related Information**  
 
 
-**Next:** [Step 15: Nested Views](../15/README.md "Our panel content is getting more and more complex and now it is time to move the panel content to a separate view. With that approach, the application structure is much easier to understand, and the individual parts of the app can be reused.")
+**Next:** [Step 15: Nested Views](../15/README.md)
 
-**Previous:** [Step 13: Margins and Paddings](../13/README.md "Our app content is still glued to the corners of the letterbox. To fine-tune our layout, we can add margins and paddings to the controls that we added in the previous step.")
+**Previous:** [Step 13: Margins and Paddings](../13/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/15/README.md
+++ b/packages/walkthrough/steps/15/README.md
@@ -162,9 +162,9 @@ We have now moved everything out of the app view and controller. The app control
 
 ***
 
-**Next:** [Step 16: Dialogs and Fragments](../16/README.md "In this step, we will take a closer look at another element which can be used to assemble views: the fragment.")
+**Next:** [Step 16: Dialogs and Fragments](../16/README.md)
 
-**Previous:** [Step 14: Margins and Paddings](../14/README.md "Sometimes we need to define some more fine-granular layouts and this is when we can use the flexibility of CSS by adding custom style classes to controls and style them as we like.")
+**Previous:** [Step 14: Margins and Paddings](../14/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/16/README.md
+++ b/packages/walkthrough/steps/16/README.md
@@ -162,9 +162,9 @@ It is a good practice to set a unique ID like `helloWorldButton` to key controls
 
 ***
 
-**Next:** [Step 17: Fragment Callbacks](../17/README.md "Now that we have integrated the dialog, it's time to add some user interaction. The user will definitely want to close the dialog again at some point, so we add a button to close the dialog and assign an event handler.")
+**Next:** [Step 17: Fragment Callbacks](../17/README.md)
 
-**Previous:** [Step15: Nested Views](../15/README.md "Our panel content is getting more and more complex and now it is time to move the panel content to a separate view. With that approach, the application structure is much easier to understand, and the individual parts of the app can be reused.")
+**Previous:** [Step15: Nested Views](../15/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/17/README.md
+++ b/packages/walkthrough/steps/17/README.md
@@ -131,9 +131,9 @@ By using the `loadFragment` function to create the fragment content in the contr
 
 ***
 
-**Next:** [Step 18: Icons](../18/README.md "Our dialog is still pretty much empty. Since  OpenUI5 is shipped with a large icon font that contains more than 500 icons, we will add an icon to greet our users when the dialog is opened.")
+**Next:** [Step 18: Icons](../18/README.md)
 
-**Previous** [Step 16: Dialogs and Fragments](../16/README.md "In this step, we will take a closer look at another element which can be used to assemble views: the fragment.")
+**Previous** [Step 16: Dialogs and Fragments](../16/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/18/README.md
+++ b/packages/walkthrough/steps/18/README.md
@@ -97,9 +97,9 @@ In the dialog fragment, we add an icon control to the content aggregation of the
 
 ***
 
-**Next:** Step 19: [Aggregation Binding](../19/README.md "Now that we have established a good structure for our app, it's time to add some more functionality. We start exploring more features of data binding by adding some invoice data in JSON format that we display in a list below the panel.")
+**Next:** Step 19: [Aggregation Binding](../19/README.md)
 
-**Previous** Step 17: [Fragment Callbacks](../17/README.md "Now that we have integrated the dialog, it's time to add some user interaction. The user will definitely want to close the dialog again at some point, so we add a button to close the dialog and assign an event handler.")
+**Previous** Step 17: [Fragment Callbacks](../17/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/19/README.md
+++ b/packages/walkthrough/steps/19/README.md
@@ -192,9 +192,9 @@ In the app view we add a second view and assign it to our newly created InvoiceL
 
 ***
 
-**Next:** Step 20: [Data Types](../20/README.md "The list of invoices is already looking nice, but what is an invoice without a price assigned? Typically prices are stored in a technical format and with a '.' delimiter in the data model. For example, our invoice for pineapples has the calculated price 87.2 without a currency. We are going to use the OpenUI5 data types to format the price properly, with a locale-dependent decimal separator and two digits after the separator.")
+**Next:** Step 20: [Data Types](../20/README.md)
 
-**Previous:** Step 18: [Icons](../18/README.md "Our dialog is still pretty much empty. Since OpenUI5 is shipped with a large icon font that contains more than 500 icons, we will add an icon to greet our users when the dialog is opened.")
+**Previous:** Step 18: [Icons](../18/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/20/README.md
+++ b/packages/walkthrough/steps/20/README.md
@@ -118,9 +118,9 @@ As you can see above, the example uses a special binding syntax for the `number`
 
 ***
 
-**Next:** [Step 21: Expression Binding](../21/README.md "Sometimes the predefined types of OpenUI5 are not flexible enough and you want to do a simple calculation or formatting in the view - that is where expressions are really helpful. We use them to format our price according to the current number in the data model.")
+**Next:** [Step 21: Expression Binding](../21/README.md)
 
-**Previous:** [Step 19: Aggregation Binding](../19/README.md "Now that we have established a good structure for our app, it's time to add some more functionality. We start exploring more features of data binding by adding some invoice data in JSON format that we display in a list below the panel.")
+**Previous:** [Step 19: Aggregation Binding](../19/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/21/README.md
+++ b/packages/walkthrough/steps/21/README.md
@@ -75,9 +75,9 @@ Expressions are limited to a particular set of operations that help formatting t
 
 ***
 
-**Next:** [Step 22: Custom Formatters](../22/README.md "If we want to do a more complex logic for formatting properties of our data model, we can also write a custom formatting function. We will now add a localized status with a custom formatter, because the status in our data model is in a rather technical format.")
+**Next:** [Step 22: Custom Formatters](../22/README.md)
 
-**Previous:** [Step 20: Data Types](../20/README.md "The list of invoices is already looking nice, but what is an invoice without a price assigned? Typically prices are stored in a technical format and with a '.' delimiter in the data model. For example, our invoice for pineapples has the calculated price 87.2 without a currency. We are going to use the OpenUI5 data types to format the price properly, with a locale-dependent decimal separator and two digits after the separator.")
+**Previous:** [Step 20: Data Types](../20/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/22/README.md
+++ b/packages/walkthrough/steps/22/README.md
@@ -163,9 +163,9 @@ in the `ObjectStatus` control we defined our alias `Formatter` that holds our fo
  
 ***
 
-**Next:** [Step 23: Filtering](../23/README.md "In this step, we add a search field for our product list and define a filter that represents the search term. When searching, the list is automatically updated to show only the items that match the search term.")
+**Next:** [Step 23: Filtering](../23/README.md)
 
-**Previous:** [Step 21: Expression Binding](../21/README.md "Sometimes the predefined types of OpenUI5 are not flexible enough and you want to do a simple calculation or formatting in the view - that is where expressions are really helpful. We use them to format our price according to the current number in the data model..")
+**Previous:** [Step 21: Expression Binding](../21/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/23/README.md
+++ b/packages/walkthrough/steps/23/README.md
@@ -152,9 +152,9 @@ The search field is part of the list header and therefore, each change on the li
  
 ***
 
-**Next:**[Step 24: Sorting and Grouping](../24/README.md "To make our list of invoices even more user-friendly, we sort it alphabetically instead of just showing the order from the data model. Additionally, we introduce groups and add the company that ships the products so that the data is easier to consume.")
+**Next:**[Step 24: Sorting and Grouping](../24/README.md)
 
-**Previous:**[Step 22: Custom Formatters](../22/README.md "If we want to do a more complex logic for formatting properties of our data model, we can also write a custom formatting function. We will now add a localized status with a custom formatter, because the status in our data model is in a rather technical format.")
+**Previous:**[Step 22: Custom Formatters](../22/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/24/README.md
+++ b/packages/walkthrough/steps/24/README.md
@@ -82,9 +82,9 @@ We could define a custom group header factory if we wanted by setting the `group
 
 ***
 
-**Next:** [Step 25: Remote OData Service](../25/README.md "So far we have worked with local JSON data, but now we will access a real OData service to visualize remote data.")
+**Next:** [Step 25: Remote OData Service](../25/README.md)
 
-**Previous:** [Step 23: Remote OData Service](../23/README.md "In this step, we add a search field for our product list and define a filter that represents the search term. When searching, the list is automatically updated to show only the items that match the search term.")
+**Previous:** [Step 23: Remote OData Service](../23/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/25/README.md
+++ b/packages/walkthrough/steps/25/README.md
@@ -126,9 +126,9 @@ As our app is now bound to a remote OData service, we do not need the `invoices.
 
 ***
 
-**Next:** [Step 26: Mock Server Configuration](../26/README.md "We just ran our app against a real service, but for developing and testing our app we do not want to rely on the availability of the “real” service or put additional load on the system where the data service is located.")
+**Next:** [Step 26: Mock Server Configuration](../26/README.md)
   
-**Previous:** [Step 24: Sorting and Grouping](../24/README.md "To make our list of invoices even more user-friendly, we sort it alphabetically instead of just showing the order from the data model. Additionally, we introduce groups and add the company that ships the products so that the data is easier to consume.")
+**Previous:** [Step 24: Sorting and Grouping](../24/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/26/README.md
+++ b/packages/walkthrough/steps/26/README.md
@@ -308,9 +308,9 @@ In case you prefer to continue with the local data, you should adjust the `start
 
 ***
 
-**Next:** [Step 27: Unit Test with QUnit](../27/README.md "Now that we have a test folder in the app, we can start to increase our test coverage.")
+**Next:** [Step 27: Unit Test with QUnit](../27/README.md)
 
-**Previous:** [Step 25: Remote OData Service](../25/README.md "So far we have worked with local JSON data, but now we will access a real OData service to visualize remote data.")
+**Previous:** [Step 25: Remote OData Service](../25/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/27/README.md
+++ b/packages/walkthrough/steps/27/README.md
@@ -284,9 +284,9 @@ If we now open the `webapp/test/testsuite.qunit.html` file in the browser and se
 
 ***
 
-**Next:** [Step 28: Integration Test with OPA](../28/README.md "If we want to test interaction patterns or more visual features of our app, we can also write an integration test.")
+**Next:** [Step 28: Integration Test with OPA](../28/README.md)
 
-**Previous:** [Step 26: Mock Server Configuration](../26/README.md "We just ran our app against a real service, but for developing and testing our app we do not want to rely on the availability of the “real” service or put additional load on the system where the data service is located.")
+**Previous:** [Step 26: Mock Server Configuration](../26/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/28/README.md
+++ b/packages/walkthrough/steps/28/README.md
@@ -261,9 +261,9 @@ If we now open the `webapp/test/testsuite.qunit.html` file in the browser and se
 
 ***
 
-**Next:** [Step 29: Debugging Tools](../29/README.md "Even though we have added a basic test coverage in the previous steps, it seems like we accidentally broke our app, because it does not display prices to our invoices anymore. We need to debug the issue and fix it before someone finds out.")
+**Next:** [Step 29: Debugging Tools](../29/README.md)
 
-**Previous:** [Step 27: Unit Test with QUnit](../27/README.md "Now that we have a test folder in the app, we can start to increase our test coverage.")
+**Previous:** [Step 27: Unit Test with QUnit](../27/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/29/README.md
+++ b/packages/walkthrough/steps/29/README.md
@@ -120,9 +120,9 @@ If you're stuck and need help for some development task, you can also post a que
 
 ***
 
-**Next:** [Step 30: Routing and Navigation](../30/README.md "So far, we have put all app content on one single page. As we add more and more features, we want to split the content and put it on separate pages.")
+**Next:** [Step 30: Routing and Navigation](../30/README.md)
 
-**Previous:** [Step 28: Integration Test with OPA](../28/README.md "If we want to test interaction patterns or more visual features of our app, we can also write an integration test.")
+**Previous:** [Step 28: Integration Test with OPA](../28/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/30/README.md
+++ b/packages/walkthrough/steps/30/README.md
@@ -353,9 +353,9 @@ If you now open the app, you should now see the detail page when clicking an ite
 
 ***
 
-**Next:** [Step 31: Routing and Navigation](../31/README.md "We can now navigate between the overview and the detail page, but the actual item that we selected in the overview is not displayed on the detail page yet. A typical use case for our app is to show additional information for the selected item on the detail page.")
+**Next:** [Step 31: Routing and Navigation](../31/README.md)
 
-**Previous:** [Step 29: Debugging Tools](../29/README.md "Even though we have added a basic test coverage in the previous steps, it seems like we accidentally broke our app, because it does not display prices to our invoices anymore. We need to debug the issue and fix it before someone finds out.")
+**Previous:** [Step 29: Debugging Tools](../29/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/31/README.md
+++ b/packages/walkthrough/steps/31/README.md
@@ -231,9 +231,9 @@ You should now see the invoice details on a separate page when you click on an i
 
 ***
 
-**Next:** [Step 32: Routing Back and History](../32/README.md "Now we can navigate to our detail page and display an invoice, but we cannot go back to the overview page yet. We'll add a back button to the detail page and implement a function that shows our overview page again.")
+**Next:** [Step 32: Routing Back and History](../32/README.md)
 
-**Previous:** [Step 30: Routing and Navigation](../30/README.md "So far, we have put all app content on one single page. As we add more and more features, we want to split the content and put it on separate pages.")
+**Previous:** [Step 30: Routing and Navigation](../30/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/32/README.md
+++ b/packages/walkthrough/steps/32/README.md
@@ -118,9 +118,9 @@ You should now see a back button when navigating to the detail page and being ab
 
 ***
 
-**Next:** [Step 33: Custom Controls](../33/README.md "We can now navigate between the overview and the detail page, but the actual item that we selected in the overview is not displayed on the detail page yet. A typical use case for our app is to show additional information for the selected item on the detail page.")
+**Next:** [Step 33: Custom Controls](../33/README.md)
 
-**Previous:** [Step 31: Routing and Navigation](../31/README.md "We can now navigate between the overview and the detail page, but the actual item that we selected in the overview is not displayed on the detail page yet. A typical use case for our app is to show additional information for the selected item on the detail page.")
+**Previous:** [Step 31: Routing and Navigation](../31/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/33/README.md
+++ b/packages/walkthrough/steps/33/README.md
@@ -606,9 +606,9 @@ Adding the block between the BEGIN and END line into the `ProductRating` class b
 
 ***
 
-**Next:** [Step 34: Responsiveness](../34/README.md "In this step, we improve the responsiveness of our app. OpenUI5 applications can be run on phone, tablet, and desktop devices and we can configure the application to make best use of the screen estate for each scenario. Fortunately, OpenUI5 controls like the sap.m.Table already deliver a lot of features that we can use.")
+**Next:** [Step 34: Responsiveness](../34/README.md)
 
-**Previous:** [Step 32: Routing Back and History](../32/README.md "Now we can navigate to our detail page and display an invoice, but we cannot go back to the overview page yet. We'll add a back button to the detail page and implement a function that shows our overview page again.")
+**Previous:** [Step 32: Routing Back and History](../32/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/34/README.md
+++ b/packages/walkthrough/steps/34/README.md
@@ -197,9 +197,9 @@ We can see the results when we decrease the browser's screen size or open the ap
 
 ***
 
-**Next:** [Step 35: Routing and Navigation](../35/README.md "We now configure the visibility and properties of controls based on the device that we run the application on. By making use of the sap.ui.Device API and defining a device model we will make the app look great on many devices.")
+**Next:** [Step 35: Routing and Navigation](../35/README.md)
 
-**Previous:** [Step 33: Debugging Tools](../33/README.md "In this step, we are going to extend the functionality of OpenUI5 with a custom control. We want to rate the product shown on the detail page, so we create a composition of multiple standard controls using the OpenUI5 extension mechanism and add some glue code to make them work nicely together. This way, we can reuse the control across the app and keep all related functionality in one module.")
+**Previous:** [Step 33: Debugging Tools](../33/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/35/README.md
+++ b/packages/walkthrough/steps/35/README.md
@@ -297,9 +297,9 @@ Optimize your application for the different screen sizes of phone, tablet, and d
 
 ***
 
-**Next:** [Step 36: Content Density](../36/README.md "In this step of our Walkthrough tutorial, we adjust the content density based on the user’s device. OpenUI5 contains different content densities allowing you to display larger controls for touch-enabled devices and a smaller, more compact design for devices that are operated by mouse. In our app, we will detect the device and adjust the density accordingly.")
+**Next:** [Step 36: Content Density](../36/README.md)
 
-**Previous:** [Step 34: Routing and Navigation](../34/README.md "We can now navigate between the overview and the detail page, but the actual item that we selected in the overview is not displayed on the detail page yet. A typical use case for our app is to show additional information for the selected item on the detail page.")
+**Previous:** [Step 34: Routing and Navigation](../34/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/36/README.md
+++ b/packages/walkthrough/steps/36/README.md
@@ -142,9 +142,9 @@ As we have just enabled the app to run in both modes depending on the devices ca
 
 ***
 
-**Next:** [Step 37: Accessibility](../37/README.md "In this step we're going to improve the accessibility of our app.")
+**Next:** [Step 37: Accessibility](../37/README.md)
 
-**Previous:** [Step 35: Routing and Navigation](../35/README.md "We now configure the visibility and properties of controls based on the device that we run the application on. By making use of the sap.ui.Device API and defining a device model we will make the app look great on many devices.")
+**Previous:** [Step 35: Routing and Navigation](../35/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/37/README.md
+++ b/packages/walkthrough/steps/37/README.md
@@ -177,9 +177,9 @@ As you can see, we now have four landmarks on our page. The top three landmarks 
 
 ***
 
-**Next:** [Step 38: Build Your Application](../38/README.md "We now configure the visibility and properties of controls based on the device that we run the application on. By making use of the `sap.ui.Device` API and defining a device model we will make the app look great on many devices.")
+**Next:** [Step 38: Build Your Application](../38/README.md)
 
-**Previous:** [Step 36: Content Density](../36/README.md "In this step of our Walkthrough tutorial, we adjust the content density based on the user’s device. OpenUI5 contains different content densities allowing you to display larger controls for touch-enabled devices and a smaller, more compact design for devices that are operated by mouse. In our app, we will detect the device and adjust the density accordingly.")
+**Previous:** [Step 36: Content Density](../36/README.md)
 
 ***
 

--- a/packages/walkthrough/steps/38/README.md
+++ b/packages/walkthrough/steps/38/README.md
@@ -82,7 +82,7 @@ You've completed the walkthrough, good job! You should now be familiar with all 
 
 ***
 
-**Previous:** [Step 37: Accessibility](../37/README.md "In this step we're going to improve the accessibility of our app.")
+**Previous:** [Step 37: Accessibility](../37/README.md)
 
 ***
 


### PR DESCRIPTION
## Problem

On the deployed GitHub Pages site, the **Next / Previous** links on the Data Binding tutorial step pages point at `README.md` instead of the rendered HTML page, so they 404. Reported for Data Binding; the same defect also affects **Walkthrough** and **Quickstart**.

## Root cause

There are two rendered doc pages per step on gh-pages, rewritten by two different mechanisms:

| Page | Rewritten by | Handles titled links? |
|------|--------------|-----------------------|
| `build/NN/README.html` | builder regex in `tools/builder/prepare-gh-pages.js` (`README.md`→`index.html`) | ✅ yes |
| `steps/NN/index.html` (linked from the tutorial landing page) | Jekyll's built-in **`jekyll-relative-links`** plugin | ❌ **no** |

`jekyll-relative-links` auto-converts relative `../NN/README.md` links to their HTML permalinks — **but it silently skips any link that carries a title attribute**:

```md
<!-- rewritten by Jekyll → works -->
**Next:** [Step 6: …](../06/README.md)

<!-- skipped by Jekyll → stays ../06/README.md → 404 on Pages -->
**Next:** [Step 6: …](../06/README.md "Business applications often require…")
```

`databinding`, `walkthrough` and `quickstart` wrote their nav links **with** a title; `navigation` and `odatav4` wrote them **without** one — which is exactly why only the former three break. Verified against the live site.

## Fix

Remove the title attribute from all **104** sibling-step `../NN/README.md` Next/Previous links across the three affected tutorials (55 files). This satisfies every rendering context:

- **GitHub in-repo navigation** — still plain relative `.md` links, unchanged.
- **Pages `steps/NN/index.html`** — Jekyll now rewrites `../06/README.md` → the correct step page.
- **Pages `build/NN/README.html`** — unaffected; the builder's own regex still rewrites `README.md`→`index.html` and preserves the hover tooltip there.

Only sibling-step nav links were touched — 122 external / demo-kit / LICENSE titled links are left intact.

## Scope

| Tutorial | Files changed |
|----------|---------------|
| databinding | 15 |
| walkthrough | 38 |
| quickstart | 2 |

The only user-visible loss is the hover tooltip on the `steps/NN/` view; it remains on the `build/…/README.html` render.

## Verification

- Reproduced on live: `databinding`/`walkthrough`/`quickstart` `steps/NN/index.html` → `../06/README.md`; `navigation`/`odatav4` → clean permalinks.
- After fix: builder regex still yields `../06/index.html` for `build/NN/README.html`; sibling target READMEs exist for in-repo nav.
- 0 titled sibling-step nav links remain repo-wide.