### PR TITLE
fix(quickstart): correct grammar in step 1 (review feedback)

### DIFF
--- a/packages/quickstart/steps/01/README.md
+++ b/packages/quickstart/steps/01/README.md
@@ -232,7 +232,7 @@ To use OpenUI5, execute the following command:
 ui5 use OpenUI5
 ```
 
-To use install the required OpenUI5 libraries, execute the following command:
+To install the required OpenUI5 libraries, execute the following command:
 
 ```sh
 ui5 add sap.m sap.tnt sap.ui.core sap.ui.layout themelib_sap_horizon
@@ -272,7 +272,7 @@ Let's break down what each package does:
 
 #### ui5.yaml
 
-Next, we have to configure the tooling extension we installed from npm to our UI5 CLI setup, so we can use them in our project. To hook a custom task into a certain build phase of a project, it needs to reference another task that will get executed before or after it. The same applies for a custom middleware:
+Next, we have to configure the tooling extension we installed from npm to our UI5 CLI setup, so we can use it in our project. To hook a custom task into a certain build phase of a project, it needs to reference another task that will get executed before or after it. The same applies for a custom middleware:
 <details class="ts-only" markdown="1">
 
 -   For the `ui5-tooling-transpile-task` we specify that this should happen after the`replaceVersion` task.


### PR DESCRIPTION
Stacked on top of #329.

Addresses the grammar review comments from @KlattG on #328 (they landed after that PR was merged, so they were never applied):

- `packages/quickstart/steps/01/README.md` — "To use install the required OpenUI5 libraries" → **"To install the required OpenUI5 libraries"** (removed the stray "use").
- `packages/quickstart/steps/01/README.md` — "so we can use them in our project" → **"so we can use it in our project"** (singular — the *tooling extension*).

Both are verbatim applications of KlattG's `suggestion` comments. No other changes.

> Note: this PR targets `fix/tutorial-rendering-consistency` (the #329 branch). Once #329 merges, GitHub will auto-retarget this to `main`.