### PR TITLE
fix(site): don't caption badges, center image captions

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -169,12 +169,16 @@ li > section.ts-only, li > section.js-only {
 
 /* Image captions rendered from each image's alt text (see renderImageCaptions
    in assets/js/custom.js). Restores the SAP Demo Kit behavior of showing the
-   image description below the figure. */
+   image description below the figure. The figure shrink-wraps to the image and
+   is centered on the page, with the caption centered beneath the image. */
 figure.img-figure {
-    margin: 16px 0;
+    display: table;
+    margin: 16px auto;
 }
 
 figure.img-figure > .img-caption {
+    display: table-caption;
+    caption-side: bottom;
     margin-top: 6px;
     font-size: 90%;
     font-style: italic;

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -297,13 +297,15 @@ function renderImageCaptions() {
 			return; // already processed
 		}
 
-		// A link-wrapped image is captioned via its anchor; otherwise the image
-		// itself is the wrap target.
-		const wrapTarget =
-			img.parentElement && img.parentElement.tagName === "A"
-				? img.parentElement
-				: img;
-		const host = wrapTarget.parentElement;
+		// Skip link-wrapped images. In the tutorials these are badges / icons
+		// (e.g. the REUSE status badge `[![…](…)](…)`), never a preview
+		// screenshot — content images are always plain `![alt](assets/…)`. A
+		// linked image should not get a caption.
+		if (img.parentElement && img.parentElement.tagName === "A") {
+			return;
+		}
+
+		const host = img.parentElement;
 		if (!host) {
 			return;
 		}
@@ -311,7 +313,7 @@ function renderImageCaptions() {
 		// Only caption block-level "preview" images — those that are the sole
 		// meaningful content of their containing block. This skips inline
 		// images sitting inside a line of prose (badges, inline icons), which
-		// should not get a centered caption. `host.textContent` is empty for a
+		// should not get a caption. `host.textContent` is empty for a
 		// standalone image because the <img> contributes no text.
 		if (host.textContent.trim() !== "") {
 			return;
@@ -324,8 +326,8 @@ function renderImageCaptions() {
 		figcaption.classList.add("img-caption");
 		figcaption.textContent = caption;
 
-		wrapTarget.parentNode.insertBefore(figure, wrapTarget);
-		figure.appendChild(wrapTarget);
+		img.parentNode.insertBefore(figure, img);
+		figure.appendChild(img);
 		figure.appendChild(figcaption);
 	});
 }


### PR DESCRIPTION
Two follow-up fixes to the alt-text image caption feature added in #329 (`renderImageCaptions` in `assets/js/custom.js`).

### 1. Badges no longer get a caption
The REUSE status badge on the root README (`[![REUSE status](…)](…)`) was rendering its alt text ("REUSE status") as a stray caption. Linked images in the tutorials are always badges/icons, never preview screenshots (content images are plain `![alt](assets/…)`), so the runtime now skips any image wrapped in an `<a>`.

### 2. Image and caption are centered together
Before, the `<figure>` was full-width and only the caption text was centered — so on a left-aligned image the caption floated to the middle of the page, disconnected from the image. Now the figure shrink-wraps to the image (`display: table; margin: 16px auto`) and is centered on the page, with the caption centered directly beneath the image.

### Verification
Checked in the browser via the local dev server:
- Root README: REUSE badge is no longer wrapped in a figure and shows no caption.
- Tutorial step pages: figure is centered on the page (equal margins) and the caption is centered under the image (image + caption centers aligned).